### PR TITLE
Adding googletest testing and email failure support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,12 +16,12 @@ node('rocm && fiji')
         }
       }
 
+      // create softlinks for clang
       sh "sudo update-alternatives --install /usr/bin/clang  clang  /usr/bin/clang-3.5 50 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.5"
 
       dir("${build_dir_release}") {
-        // create softlinks for clang
         stage("configure clang release") {
-          sh "cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRARY=ON -DBUILD_CLIENTS=ON -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DHIP_ROOT=/opt/rocm/hip -DBOOST_ROOT=/opt/boost/clang -DFFTW_ROOT=/usr/lib ${scm_dir}"
+          sh "cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRARY=ON -DBUILD_CLIENTS=ON -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_RIDER=ON -DHIP_ROOT=/opt/rocm/hip -DBOOST_ROOT=/opt/boost/clang -DFFTW_ROOT=/usr/lib ${scm_dir}"
         }
 
         stage("Build") {
@@ -33,37 +33,55 @@ node('rocm && fiji')
           archive includes: 'library-build/*.deb'
         }
 
-        stage("samples") {
-          sh "cd clients-build/samples-build/fixed-16; ./fixed-16"
-        }
-
         stage("unit tests") {
-          // junit 'test_detail.xml'
+          sh '''
+              cd clients-build/tests-build/staging
+              ./rocfft-test-correctness-d --gtest_output=xml
+          '''
+          junit 'clients-build/tests-build/staging/*.xml'
         }
+
+        stage("rider") {
+          sh '''
+              cd clients-build/rider-build/staging
+              ./rocfft-rider-d -x 16
+              ./rocfft-rider-d -x 256
+              ./rocfft-rider-d -x 1024
+          '''
+        }
+
+        // stage("samples") {
+        //   sh '''
+        //       cd clients-build/samples-build/fixed-16
+        //       ./fixed-16
+        //     '''
+        // }
       }
 
-      dir("${build_dir_debug}") {
-        stage("clang-tidy checks") {
-          sh "cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_LIBRARY=ON -DHIP_ROOT=/opt/rocm/hip -DCMAKE_CXX_CLANG_TIDY=\"clang-tidy-3.5;-checks=*\" ${scm_dir}"
-          sh 'make'
-        }
-      }
+      // dir("${build_dir_debug}") {
+      //   stage("clang-tidy checks") {
+      //     sh "cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_LIBRARY=ON -DHIP_ROOT=/opt/rocm/hip -DCMAKE_CXX_CLANG_TIDY=\"clang-tidy-3.5;-checks=*\" ${scm_dir}"
+      //     sh 'make'
+      //   }
+      // }
     }
     catch( err )
     {
         currentBuild.result = "FAILURE"
 
-        // emailext pipeline projects do not seem to support token expansions yet, such as ${env.JOB_NAME}
-        // emailext recipientProviders: [[$class: 'CulpritsRecipientProvider']], to: 'dl.library-team@amd.com'
-
-        // mail job does not appear to work with emailextrecipients
         def email_list = emailextrecipients([
                 [$class: 'CulpritsRecipientProvider']
         ])
 
-        mail  to: 'kent.knox@amd.com, bragadeesh.natarajan@amd.com, tingxing.dong@amd.com',
+        // CulpritsRecipientProvider below doesn't help, because nobody uses their real email address
+        // emailext  to: "kent.knox@amd.com", recipientProviders: [[$class: 'CulpritsRecipientProvider']],
+        //       subject: "${env.JOB_NAME} finished with ${currentBuild.result}",
+        //       body: "Node: ${env.NODE_NAME}\nSee ${env.BUILD_URL}\n\n" + err.toString()
+
+        mail  to: "kent.knox@amd.com, bragadeesh.natarajan@amd.com, tingxing.dong@amd.com",
               subject: "${env.JOB_NAME} finished with ${currentBuild.result}",
-              body: "Node: ${env.NODE_NAME}\nSee ${env.BUILD_URL}\n"
+              body: "Node: ${env.NODE_NAME}\nSee ${env.BUILD_URL}\n\n" + err.toString()
+
         throw err
     }
 }


### PR DESCRIPTION
Summary of proposed changes:
-  Making fiji dependency explicit; testing only on fiji hardware for now
-  Adding email support for failed builds
-  Adding googletest runs and dashboard
