### PR TITLE
generate large 1D pow2, first version

### DIFF
--- a/library/src/device/generator/generator.kernel.hpp
+++ b/library/src/device/generator/generator.kernel.hpp
@@ -220,7 +220,7 @@ namespace StockhamGenerator
             if (r2c2r)
                 return false;
 
-            if (realSpecial)  
+            if (realSpecial)
               return false;
 
             for (size_t i = 0; i < params.fft_DataDim-1; i++)//if it is power of 2
@@ -241,12 +241,12 @@ namespace StockhamGenerator
              can be stride_in or stride_out, they are vector<size_t> type
           output
              if true, offset_name2, stride_name2 are enabled
-             else not enabled 
+             else not enabled
         */
 
         //since it is batching process mutiple matrices by default, calculate the offset block
-        inline std::string OffsetCalcBlock(const std::string offset_name1, const std::string stride_name1, 
-                                           const std::string offset_name2, const std::string stride_name2,  
+        inline std::string OffsetCalcBlock(const std::string offset_name1, const std::string stride_name1,
+                                           const std::string offset_name2, const std::string stride_name2,
                                            bool input, bool output)
         {
             std::string str;
@@ -257,17 +257,17 @@ namespace StockhamGenerator
             loop += "\tfor(int i = dim; i>2; i--){\n";//dim is a runtime variable
             loop += "\t\tint currentLength = 1;\n";
             loop += "\t\tfor(int j=2; j<i; j++){\n";
-            loop += "\t\t\tcurrentLength *= lengths[j];\n";  
+            loop += "\t\t\tcurrentLength *= lengths[j];\n";
             loop += "\t\t}\n";
             loop += "\t\tcurrentLength *= (lengths[1]/" + std::to_string(blockWidth) + ");\n";
             loop += "\n";
             loop +=  "\t\t" + offset_name1 + " += (counter_mod/currentLength)*" + stride_name1 + "[i];\n" ;
-            if (output == true) 
+            if (output == true)
                  loop +=  "\t\t" + offset_name2 + " += (counter_mod/currentLength)*" + stride_name2 + "[i];\n" ;
             loop += "\t\tcounter_mod = (counter_mod % currentLength); \n";
             loop += "\t}\n";
 
-            std::string sub_string = "(lengths[1]/" + std::to_string(blockWidth) + ")";// in FFT it is how many unrolls 
+            std::string sub_string = "(lengths[1]/" + std::to_string(blockWidth) + ")";// in FFT it is how many unrolls
 
             loop +=  "\t" + offset_name1 + " += (counter_mod/" + sub_string + ")*" ;
             loop +=  stride_name1 + "[2] + (counter_mod % " + sub_string + ")*" + std::to_string(blockWidth);
@@ -284,7 +284,7 @@ namespace StockhamGenerator
             }
 
             str += loop;
-            return str;            
+            return str;
         }
 
         /*
@@ -296,11 +296,11 @@ namespace StockhamGenerator
              can be stride_in or stride_out, they are vector<size_t> type
           output
              if true, offset_name2, stride_name2 are enabled
-             else not enabled 
+             else not enabled
         */
 
-        inline std::string OffsetCalc(const std::string offset_name1, const std::string stride_name1, 
-                                      const std::string offset_name2, const std::string stride_name2,  
+        inline std::string OffsetCalc(const std::string offset_name1, const std::string stride_name1,
+                                      const std::string offset_name2, const std::string stride_name2,
                                       bool output, bool rc_second_index = false)
         {
             std::string str;
@@ -339,7 +339,7 @@ namespace StockhamGenerator
                 int counter_1 = counter_mod / lengths[1];
                 int counter_mod_1 = counter_mod % lengths[1];
 
-                iOffset += counter_1*strides[2] + counter_mod_1*strides[1]; 
+                iOffset += counter_1*strides[2] + counter_mod_1*strides[1];
             }
             else if(dim == 3){
                 int counter_2 = counter_mod / (lengths[1] * lengths[2]);
@@ -348,7 +348,7 @@ namespace StockhamGenerator
                 int counter_1 = counter_mod_2 / lengths[1];
                 int counter_mod_1 = counter_mod_2 % lengths[1];
 
-                iOffset += counter_2*strides[3] + counter_1*strides[2] + counter_mod_1*strides[1]; 
+                iOffset += counter_2*strides[3] + counter_1*strides[2] + counter_mod_1*strides[1];
             }
             else{
                 for(int i = dim; i>1; i--){
@@ -374,8 +374,8 @@ namespace StockhamGenerator
             loop += "\telse if(dim == 2){\n";
             loop += "\t\tint counter_1 = counter_mod / lengths[1];\n";
             loop += "\t\tint counter_mod_1 = counter_mod % lengths[1];\n";
-            loop += "\t\t" + offset_name1 + " += counter_1*"+ stride_name1 + "[2] + counter_mod_1*" + stride_name1 + "[1];\n"; 
-            if (output == true) loop += "\t\t" + offset_name2 + " += counter_1*"+ stride_name2 + "[2] + counter_mod_1*" + stride_name2 + "[1];\n"; 
+            loop += "\t\t" + offset_name1 + " += counter_1*"+ stride_name1 + "[2] + counter_mod_1*" + stride_name1 + "[1];\n";
+            if (output == true) loop += "\t\t" + offset_name2 + " += counter_1*"+ stride_name2 + "[2] + counter_mod_1*" + stride_name2 + "[1];\n";
             loop += "\t}\n";
 
             loop += "\telse if(dim == 3){\n";
@@ -383,9 +383,9 @@ namespace StockhamGenerator
             loop += "\t\tint counter_mod_2 = counter_mod % (lengths[1] * lengths[2]);\n";
             loop += "\t\tint counter_1 = counter_mod_2 / lengths[1];\n";
             loop += "\t\tint counter_mod_1 = counter_mod_2 % lengths[1];\n";
-            loop += "\t\t" + offset_name1 + " += counter_2*"+ stride_name1 + "[3] + counter_1*"+ stride_name1 + "[2] + counter_mod_1*" + stride_name1 + "[1];\n"; 
-            if (output == true) 
-                loop += "\t\t" + offset_name2 + " += counter_2*"+ stride_name2 + "[3] + counter_1*"+ stride_name2 + "[2] + counter_mod_1*" + stride_name2 + "[1];\n"; 
+            loop += "\t\t" + offset_name1 + " += counter_2*"+ stride_name1 + "[3] + counter_1*"+ stride_name1 + "[2] + counter_mod_1*" + stride_name1 + "[1];\n";
+            if (output == true)
+                loop += "\t\t" + offset_name2 + " += counter_2*"+ stride_name2 + "[3] + counter_1*"+ stride_name2 + "[2] + counter_mod_1*" + stride_name2 + "[1];\n";
             loop += "\t}\n";
 
             loop += "\telse{\n";
@@ -402,7 +402,7 @@ namespace StockhamGenerator
             loop += "\t\t" + offset_name1 + "+= counter_mod * " + stride_name1  + "[1];\n";
             if (output == true)    loop += "\t\t" + offset_name2 + "+= counter_mod * " + stride_name2  + "[1];\n";
             loop += "\t}\n";
-            
+
             str += loop;
 
             return str;
@@ -569,7 +569,7 @@ namespace StockhamGenerator
 
             // Grouping read/writes ok?
             bool grp = IsGroupedReadWritePossible();
-            printf("len=%d, grp = %d\n", length, grp);
+            //printf("len=%d, grp = %d\n", length, grp);
             for (size_t i = 0; i < numPasses; i++)
                 passes[i].SetGrouping(grp);
 
@@ -762,17 +762,17 @@ namespace StockhamGenerator
                     else  str += "back_len";
                     str += std::to_string(length);
                     str += "_device";
-                    str += "(const T *twiddles, const size_t stride_in, const size_t stride_out, unsigned int rw, unsigned int b, "; 
-                    str += "unsigned int me, unsigned int ldsOffset, T *lwbIn, T *lwbOut"; 
-                    
-                    if (blockCompute)// blockCompute' lds type is T 
+                    str += "(const T *twiddles, const size_t stride_in, const size_t stride_out, unsigned int rw, unsigned int b, ";
+                    str += "unsigned int me, unsigned int ldsOffset, T *lwbIn, T *lwbOut";
+
+                    if (blockCompute)// blockCompute' lds type is T
                     {
                         str += ", T *lds";
                     }
                     else
                     {
                         if (numPasses > 1) str += ", real_type_t<T> *lds"; //only multiple pass use lds
-                    } 
+                    }
 
                     str += ")\n";
                     str += "{\n";
@@ -789,7 +789,7 @@ namespace StockhamGenerator
                     {
                         str += "\t";
                         str += PassName(0, fwd, length);
-                        str += "<T, sb>(twiddles, stride_in, stride_out, rw, b, me, 0, 0, lwbIn, lwbOut"; 
+                        str += "<T, sb>(twiddles, stride_in, stride_out, rw, b, me, 0, 0, lwbIn, lwbOut";
                         str += IterRegs("&");
                         str += ");\n";
                     }
@@ -802,7 +802,7 @@ namespace StockhamGenerator
                             str += exTab;
                             str += "\t";
                             str += PassName(p->GetPosition(), fwd, length);
-                            str += "<T, sb>(twiddles, stride_in, stride_out, rw, b, me, "; 
+                            str += "<T, sb>(twiddles, stride_in, stride_out, rw, b, me, ";
 
                             std::string ldsArgs;
                             if (halfLds) { ldsArgs += "lds, lds"; }
@@ -823,7 +823,7 @@ namespace StockhamGenerator
                                     str += "0, ";
                                 }
                                 str += "ldsOffset, lwbIn, ";
-                                str += ldsArgs; 
+                                str += ldsArgs;
                             }
                             else if ((p + 1) == passes.end()) // ending pass
                             {
@@ -836,16 +836,16 @@ namespace StockhamGenerator
                                 {
                                     str += "0, ";
                                 }
-                                str += ldsArgs; 
-                                str += ", lwbOut"; 
+                                str += ldsArgs;
+                                str += ", lwbOut";
                             }
                             else // intermediate pass
                             {
                                 str += "ldsOffset, ldsOffset, ";
-                                str += ldsArgs; str += ", "; str += ldsArgs; 
+                                str += ldsArgs; str += ", "; str += ldsArgs;
                             }
 
-                            str += IterRegs("&"); 
+                            str += IterRegs("&");
                             str += ");\n";
                             if (!halfLds) { str += exTab; str += "\t__syncthreads();\n"; }
                         }
@@ -870,9 +870,9 @@ namespace StockhamGenerator
                     bool fwd;
                     fwd = d ? false : true;
 
-                    str += "//Kernel configuration: number of threads per thread block: "; 
+                    str += "//Kernel configuration: number of threads per thread block: ";
                     if (blockCompute) str += std::to_string(blockWGS);
-                    else str += std::to_string (workGroupSize); 
+                    else str += std::to_string (workGroupSize);
                     str += " transforms: " + std::to_string(numTrans) + " Passes: " + std::to_string(numPasses) + "\n";
                     // FFT kernel begin
                     // Function signature
@@ -1030,7 +1030,7 @@ namespace StockhamGenerator
 
                     // Conditional read-write ('rw') controls each thread behavior when it is not divisible
                     // for 2D, 3D layout, the "upper_count" viewed by kernels is batch_count*length[1]*length[2]*...*length[dim-1]
-                    // because we flatten other dimensions to 1D dimension when configurating the thread blocks  
+                    // because we flatten other dimensions to 1D dimension when configurating the thread blocks
                     if ((numTrans > 1) && !blockCompute)
                     {
                             str += "\tunsigned int upper_count = batch_count;\n";
@@ -1053,8 +1053,8 @@ namespace StockhamGenerator
                     str += "\t#else\n";
                     str += "\t\t(void)rw;\n";
                     str += "\t#endif\n";
-                    
-                    
+
+
                     //printf("fft_3StepTwiddle = %d, lengths = %zu\n", params.fft_3StepTwiddle, length);
 
                     // Transform index for 3-step twiddles
@@ -1163,7 +1163,7 @@ namespace StockhamGenerator
                         inOffset += "iOffset";
                         outOffset += "oOffset";
                     }
-                  
+
                     /* =====================================================================
                         blockCompute only: Read data into shared memory (LDS) for blocked access
                        =================================================================== */
@@ -1176,7 +1176,7 @@ namespace StockhamGenerator
                         str += "\n\tfor(unsigned int t=0; t<"; str += std::to_string(loopCount);
                         str += "; t++)\n\t{\n";
 
-                        //get offset 
+                        //get offset
                         std::string bufOffset;
 
                         for (size_t c = 0; c<2; c++)
@@ -1191,12 +1191,12 @@ namespace StockhamGenerator
                             {
                                 bufOffset.clear();
                                 bufOffset += "(me%"; bufOffset += std::to_string(blockWidth); bufOffset += ") + ";
-                                bufOffset += "(me/"; bufOffset += std::to_string(blockWidth); bufOffset += ")*stride_in[0] + t*stride_in[0]*"; 
+                                bufOffset += "(me/"; bufOffset += std::to_string(blockWidth); bufOffset += ")*stride_in[0] + t*stride_in[0]*";
                                 bufOffset += std::to_string(blockWGS / blockWidth);
-                                
+
                                 str += "\t\tR0"; str += comp; str += " = ";
                                 str += readBuf; str += "[";	str += bufOffset; str += "];\n";
-                                
+
                             }
                             else
                             {
@@ -1224,7 +1224,7 @@ namespace StockhamGenerator
 
 
                     /* =====================================================================
-                        Set rw and 'me' 
+                        Set rw and 'me'
                         rw string also contains 'b'
                        =================================================================== */
 
@@ -1266,7 +1266,7 @@ namespace StockhamGenerator
                         call FFT devices functions in the generated kernel
                        =================================================================== */
 
-                    if (blockCompute)// for blockCompute, a loop is required, inBuf, outBuf would be overwritten 
+                    if (blockCompute)// for blockCompute, a loop is required, inBuf, outBuf would be overwritten
                     {
                         str += "\n\tfor(unsigned int t=0; t<"; str += std::to_string(blockWidth / (blockWGS / workGroupSizePerTrans));
                         str += "; t++)\n\t{\n\n";
@@ -1289,7 +1289,7 @@ namespace StockhamGenerator
 
                     std::string ldsOff;
 
-                    if (blockCompute)//blockCompute changes the ldsOff 
+                    if (blockCompute)//blockCompute changes the ldsOff
                     {
                         ldsOff += "t*"; ldsOff += std::to_string(length*(blockWGS / workGroupSizePerTrans)); ldsOff += " + (me/";
                         ldsOff += std::to_string(workGroupSizePerTrans); ldsOff += ")*"; ldsOff += std::to_string(length);
@@ -1315,7 +1315,7 @@ namespace StockhamGenerator
 
                     str += rw;
                     str += me;
-                    str += ldsOff + ", "; 
+                    str += ldsOff + ", ";
 
                     str += inBuf + outBuf;
 
@@ -1327,7 +1327,7 @@ namespace StockhamGenerator
 
                     if (blockCompute || realSpecial)// the "}" enclose the loop introduced by blockCompute
                     {
-                        str += "\n\t}\n\n"; 
+                        str += "\n\t}\n\n";
                     }
 
                     // Write data from shared memory (LDS) for blocked access
@@ -1375,7 +1375,7 @@ namespace StockhamGenerator
                             if (outInterleaved) break;
                         }
 
-                        str += "\t}\n\n";// "}" enclose the loop intrduced 
+                        str += "\t}\n\n";// "}" enclose the loop intrduced
                      }// end if blockCompute
 
                      str += "}\n\n";// end the kernel

--- a/library/src/device/generator/generator.kernel.hpp
+++ b/library/src/device/generator/generator.kernel.hpp
@@ -1194,13 +1194,13 @@ namespace StockhamGenerator
                                 bufOffset += "(me/"; bufOffset += std::to_string(blockWidth); bufOffset += ")*stride_in[0] + t*stride_in[0]*";
                                 bufOffset += std::to_string(blockWGS / blockWidth);
 
-                                str += "\t\tR0"; str += comp; str += " = ";
+                                str += "\t\tT R0"; str += comp; str += " = ";
                                 str += readBuf; str += "[";	str += bufOffset; str += "];\n";
 
                             }
                             else
                             {
-                                str += "\t\tR0"; str += comp; str += " = "; str += readBuf; str += "[me + t*"; str += std::to_string(blockWGS); str += "];\n";
+                                str += "\t\tT R0"; str += comp; str += " = "; str += readBuf; str += "[me + t*"; str += std::to_string(blockWGS); str += "];\n";
                             }
 
 
@@ -1311,7 +1311,8 @@ namespace StockhamGenerator
                     if(fwd) str += "fwd_len";
                     else  str += "back_len";
                     str += std::to_string(length);
-                    str += "_device<T, sb>(twiddles, stride_in[0], stride_in[0],";
+                    str += "_device<T, sb>(twiddles, stride_in[0], ";
+                    str += ( (placeness == rocfft_placement_inplace) ? "stride_in[0], " : "stride_out[0], " );
 
                     str += rw;
                     str += me;
@@ -1342,13 +1343,13 @@ namespace StockhamGenerator
 
                         if ((blockComputeType == BCT_C2C) || (blockComputeType == BCT_R2C))
                         {
-                            str += "\t\tR0 = lds[t*"; str += std::to_string(blockWGS / blockWidth); str += " + ";
+                            str += "\t\tT R0 = lds[t*"; str += std::to_string(blockWGS / blockWidth); str += " + ";
                             str += "(me%"; str += std::to_string(blockWidth); str += ")*"; str += std::to_string(length); str += " + ";
                             str += "(me/"; str += std::to_string(blockWidth); str += ")];"; str += "\n";
                         }
                         else
                         {
-                            str += "\t\tR0 = lds[t*"; str += std::to_string(blockWGS); str += " + me];"; str += "\n";
+                            str += "\t\tT R0 = lds[t*"; str += std::to_string(blockWGS); str += " + me];"; str += "\n";
                         }
 
                         for (size_t c = 0; c<2; c++)
@@ -1363,7 +1364,8 @@ namespace StockhamGenerator
                             {
                                 {
                                     str += "\t\t"; str += writeBuf; str += "[(me%"; str += std::to_string(blockWidth); str += ") + ";
-                                    str += "(me/"; str += std::to_string(blockWidth); str += ")*stride_out[0] + t*stride_out[0]*";
+                                    str += "(me/"; str += std::to_string(blockWidth); 
+                                    str += ( (placeness == rocfft_placement_inplace) ? ")*stride_in[0] + t*stride_in[0]*" : ")*stride_out[0] + t*stride_out[0]*" );
                                     str += std::to_string(blockWGS / blockWidth); str += "] = R0"; str += comp; str += ";\n";
                                 }
                             }

--- a/library/src/device/generator/generator.main.cpp
+++ b/library/src/device/generator/generator.main.cpp
@@ -382,7 +382,7 @@ int generate_kernel(int len)
                 case 32768: 
                     large1D_first_dim = 128; blockCompute = true; break;
                 case 65536: 
-                    large1D_first_dim = 128; blockCompute = true; break;
+                    large1D_first_dim = 256; blockCompute = true; break;
                 default: 
                     large1D_first_dim = 64; blockCompute = false;
         }
@@ -392,12 +392,12 @@ int generate_kernel(int len)
             if(i==0){
                 fft_N[0] = large1D_first_dim;
                 fft_N[1] = len/large1D_first_dim;
-                blockComputeType = BCT_C2R; //BCT_C2R, R2C, C2C
+                blockComputeType = BCT_C2C; //from global memory point view
             }
             else{
                 fft_N[1] = large1D_first_dim;
                 fft_N[0] = len/large1D_first_dim;
-                blockComputeType = BCT_C2C;
+                blockComputeType = BCT_R2C;
             }
                     
             initParams(params, fft_N, blockCompute, blockComputeType);// the last is about set blockCompute or not 
@@ -534,6 +534,11 @@ int main(int argc, char *argv[])
          all_possible(support_list, 3125, 2187, 4096);
     }
 
+   //manually add 8K-64K of pow2
+    support_list.push_back(8192);
+    support_list.push_back(16384);                    
+    support_list.push_back(32768);
+    support_list.push_back(65536);
 
     for(size_t i=0;i<support_list.size();i++){
         //printf("Generating len %d FFT kernels\n", support_list[i]);
@@ -547,10 +552,8 @@ int main(int argc, char *argv[])
     }
 */
 
-
     //printf("Generating CPU Header \n");
     WriteCPUHeaders(support_list);
-
 
     //printf("Generating CPU wrappers \n");
     WriteCPUWrappersSingle(support_list);

--- a/library/src/device/generator/generator.param.h
+++ b/library/src/device/generator/generator.param.h
@@ -13,104 +13,115 @@
                 Parameter used to control kernel generation
                =================================================================== */
 
+enum BlockComputeType
+{
+    BCT_C2C,    // Column to column
+    BCT_C2R,    // Column to row
+    BCT_R2C,    // Row to column
+};
+
+
 struct FFTKernelGenKeyParams {
 
 #define ROCFFT_MAX_INTERNAL_DIM 16
-	/*
-	 *	This structure distills a subset of the fftPlan data,
-	 *	including all information that is used to generate the FFT kernel.
-	 *	This structure can be used as a key to reusing kernels that have already
-	 *	been compiled.
-	 */
-	size_t                   fft_DataDim;       // Dimensionality of the data
-	size_t                   fft_N[ROCFFT_MAX_INTERNAL_DIM];          // [0] is FFT size, e.g. 1024
-	                                            // This must be <= size of LDS!
-	size_t                   fft_inStride [ROCFFT_MAX_INTERNAL_DIM];  // input strides
-	size_t                   fft_outStride[ROCFFT_MAX_INTERNAL_DIM];  // output strides
+    /*
+     *    This structure distills a subset of the fftPlan data,
+     *    including all information that is used to generate the FFT kernel.
+     *    This structure can be used as a key to reusing kernels that have already
+     *    been compiled.
+     */
+    size_t                   fft_DataDim;       // Dimensionality of the data
+    size_t                   fft_N[ROCFFT_MAX_INTERNAL_DIM];          // [0] is FFT size, e.g. 1024
+                                                // This must be <= size of LDS!
+    //size_t                   fft_inStride [ROCFFT_MAX_INTERNAL_DIM];  // input strides, TODO: in rocFFT, stride is a run-time parameter of the kernel
+    //size_t                   fft_outStride[ROCFFT_MAX_INTERNAL_DIM];  // output strides TODO: in rocFFT, stride is a run-time parameter of the kernel
 
-	rocfft_array_type        fft_inputLayout;
-	rocfft_array_type        fft_outputLayout;
-	rocfft_precision         fft_precision;
-	double                   fft_fwdScale;
-	double                   fft_backScale;
+    rocfft_array_type        fft_inputLayout;
+    rocfft_array_type        fft_outputLayout;
+    rocfft_precision         fft_precision;
+    double                   fft_fwdScale;
+    double                   fft_backScale;
 
-	size_t                   fft_workGroupSize;          // Assume this workgroup size
-	size_t                   fft_LDSsize;       // Limit the use of LDS to this many bytes.
-	size_t                   fft_numTrans;      // # numTransforms in a workgroup
+    size_t                   fft_workGroupSize;          // Assume this workgroup size
+    size_t                   fft_LDSsize;       // Limit the use of LDS to this many bytes.
+    size_t                   fft_numTrans;      // # numTransforms in a workgroup
 
 
-	size_t					 fft_MaxWorkGroupSize; // Limit for work group size
+    size_t                     fft_MaxWorkGroupSize; // Limit for work group size
 
-	bool                     fft_3StepTwiddle;  // This is one pass of the "3-step" algorithm;
-	                                            // so extra twiddles are applied on output.
-	bool					 fft_twiddleFront;	// do twiddle scaling at the beginning pass
+    bool                     fft_3StepTwiddle;  // This is one pass of the "3-step" algorithm;
+                                                // so extra twiddles are applied on output.
+    bool                     fft_twiddleFront;    // do twiddle scaling at the beginning pass
 
-	bool					 fft_realSpecial;	// this is the flag to control the special case step (4th step)
-	                                            // in the 5-step real 1D large breakdown
-	size_t					 fft_realSpecial_Nr;
+    bool                     fft_realSpecial;    // this is the flag to control the special case step (4th step)
+                                                // in the 5-step real 1D large breakdown
+    size_t                     fft_realSpecial_Nr;
 
-	bool                     fft_RCsimple;
+    bool                     fft_RCsimple;
 
-	bool					 transOutHorizontal;	// tiles traverse the output buffer in horizontal direction
+    bool                     transOutHorizontal;    // tiles traverse the output buffer in horizontal direction
 
-	bool					 blockCompute;
-	size_t					 blockSIMD;
-	size_t					 blockLDS;
+    bool                     blockCompute;
+    size_t                     blockSIMD;
+    size_t                     blockLDS;
 
-	// sometimes non square matrix are broken down into a number of
-	// square matrix during inplace transpose
-	// let's call this number transposeMiniBatchSize
-	// no user of the library should set its value
-	size_t transposeMiniBatchSize;
-	// transposeBatchSize is the number of batchs times transposeMiniBatchSzie
-	// no user of the library should set its value
-	size_t transposeBatchSize;
+    BlockComputeType blockComputeType;
+
+    // sometimes non square matrix are broken down into a number of
+    // square matrix during inplace transpose
+    // let's call this number transposeMiniBatchSize
+    // no user of the library should set its value
+    size_t transposeMiniBatchSize;
+    // transposeBatchSize is the number of batchs times transposeMiniBatchSzie
+    // no user of the library should set its value
+    size_t transposeBatchSize;
 
     bool fft_hasPreCallback; // two call back variable
     bool fft_hasPostCallback;
 
-	long   limit_LocalMemSize;
+    long   limit_LocalMemSize;
 
-	// Default constructor
-	FFTKernelGenKeyParams()
-	{
-		fft_DataDim = 0;
-		for(int i=0; i<ROCFFT_MAX_INTERNAL_DIM; i++)
-		{
-			fft_N[i] = 0;
-			fft_inStride[i] = 0;
-			fft_outStride[i] = 0;
-		}
+    // Default constructor
+    FFTKernelGenKeyParams()
+    {
+        fft_DataDim = 0;
+        for(int i=0; i<ROCFFT_MAX_INTERNAL_DIM; i++)
+        {
+            fft_N[i] = 0;
+            //fft_inStride[i] = 0;
+            //fft_outStride[i] = 0;
+        }
 
 
-		fft_inputLayout = rocfft_array_type_complex_interleaved;
-		fft_outputLayout = rocfft_array_type_complex_interleaved;
-		fft_precision = rocfft_precision_single;
-		fft_fwdScale = fft_backScale = 0.0;
-		fft_workGroupSize = 0;
-		fft_LDSsize = 0;
-		fft_numTrans = 1;
-		fft_MaxWorkGroupSize = 256;
-		fft_3StepTwiddle = false;
-		fft_twiddleFront = false;
+        fft_inputLayout = rocfft_array_type_complex_interleaved;
+        fft_outputLayout = rocfft_array_type_complex_interleaved;
+        fft_precision = rocfft_precision_single;
+        fft_fwdScale = fft_backScale = 0.0;
+        fft_workGroupSize = 0;
+        fft_LDSsize = 0;
+        fft_numTrans = 1;
+        fft_MaxWorkGroupSize = 256;
+        fft_3StepTwiddle = false;
+        fft_twiddleFront = false;
 
-		transOutHorizontal = false;
+        transOutHorizontal = false;
 
-		fft_realSpecial = false;
-		fft_realSpecial_Nr = 0;
+        fft_realSpecial = false;
+        fft_realSpecial_Nr = 0;
 
-		fft_RCsimple = false;
+        fft_RCsimple = false;
 
-		blockCompute = false;
-		blockSIMD = 0;
-		blockLDS = 0;
+        blockCompute = false;
+        blockSIMD = 0;
+        blockLDS = 0;
+        blockComputeType = BCT_C2C;
 
-		transposeMiniBatchSize = 1;
-		transposeBatchSize = 1;
-		fft_hasPreCallback = false;
-		fft_hasPostCallback = false;
-		limit_LocalMemSize = 0;
-	}
+        transposeMiniBatchSize = 1;
+        transposeBatchSize = 1;
+        fft_hasPreCallback = false;
+        fft_hasPostCallback = false;
+        limit_LocalMemSize = 0;
+    }
 };
 
 


### PR DESCRIPTION
-  generate large 1D kernels of pow2 from 8K to 64K (but the CPU calling part need to update, too) 
-  add blockCompute feature in generator
-  modify offsetCalcBlock to make stride as a runtime parameter of kernels
-  remove stride check in generator, as stride is passed as an run-time variable of kernels 
-  this pull request does not change small 1D (<= 4K) kernels. 
