### PR TITLE
Turn off git hash versioning in rocm-cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ include( ROCMInstallTargets )
 include( ROCMPackageConfigHelpers )
 include( ROCMInstallSymlinks )
 
-rocm_setup_version( VERSION 0.3.0.0 )
+rocm_setup_version( VERSION 0.3.0.0 NO_GIT_TAG_VERSION )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH


### PR DESCRIPTION
resolves #94 

Summary of proposed changes:
- Upstream rocm-cmake changed, and we turn off the new feature which breaks how we link to our device library 
