### PR TITLE
Use hip device target when available

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -58,7 +58,13 @@ add_library( rocfft ${rocfft_source} ${relative_rocfft_headers_public} )
 add_library( roc::rocfft ALIAS rocfft )
 target_compile_features( rocfft PRIVATE cxx_static_assert cxx_nullptr cxx_auto_type )
 
-target_link_libraries( rocfft PRIVATE hip::hip_hcc hip::hip_device hcc::hccshared rocfft-device )
+# Remove this check when we no longer build with older rocm stack(ie < 1.8.2)
+if(TARGET hip::device)
+target_link_libraries( rocfft PRIVATE hip::device )
+else()
+target_link_libraries( rocfft PRIVATE hip::hip_hcc hip::hip_device hcc::hccshared )
+endif()
+target_link_libraries( rocfft PRIVATE rocfft-device )
 
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1

--- a/library/src/device/CMakeLists.txt
+++ b/library/src/device/CMakeLists.txt
@@ -72,7 +72,12 @@ add_library( rocfft-device
 add_library( roc::rocfft-device ALIAS rocfft-device )
 target_compile_features( rocfft-device PRIVATE cxx_static_assert cxx_nullptr cxx_auto_type )
 
+# Remove this check when we no longer build with older rocm stack(ie < 1.8.2)
+if(TARGET hip::device)
+target_link_libraries( rocfft-device PRIVATE hip::device )
+else()
 target_link_libraries( rocfft-device PRIVATE hip::hip_hcc hip::hip_device hcc::hccshared )
+endif()
 
 if(HIP_PLATFORM STREQUAL "nvcc")
     target_compile_options( rocfft-device PRIVATE "-gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_30,code=sm_30" )


### PR DESCRIPTION
This applies a hotfix, so rocFFT can build with hcc/hip from rocm 1.8.2.
