### PR TITLE
cmake fix to rocm-export-targets

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -112,7 +112,7 @@ rocm_install_targets(
 #         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
 
 rocm_export_targets(
-  TARGETS rocfft-targets
+  TARGETS roc::rocfft
   PREFIX rocfft
   DEPENDS PACKAGE hip
   NAMESPACE roc::


### PR DESCRIPTION
Fixes cmake issue with ${ROCFFT_LIBRARIES} environment variable that was previously pointing to librocfft-targets.so.