### PR TITLE
fix for case sensitive cmake to find HIP dependency

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -114,7 +114,7 @@ rocm_install_targets(
 rocm_export_targets(
   TARGETS roc::rocfft
   PREFIX rocfft
-  DEPENDS PACKAGE hip
+  DEPENDS PACKAGE HIP
   NAMESPACE roc::
  )
 


### PR DESCRIPTION
resolves issues with case sensitive cmake to find HIP dependency (CentOS 7.5 w/ CMake 3.12)