### PR TITLE
Versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ include( ROCMInstallTargets )
 include( ROCMPackageConfigHelpers )
 include( ROCMInstallSymlinks )
 
-rocm_setup_version( VERSION 0.8.6.0 NO_GIT_TAG_VERSION )
+rocm_setup_version( VERSION 0.8.6.0 PARSE_VERSION )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH

--- a/clients/rider/rider.cpp
+++ b/clients/rider/rider.cpp
@@ -784,7 +784,9 @@ int main( int argc, char* argv[] )
 
 		if( vm.count( "version" ) )
 		{
-			std::cout << "version" << std::endl;
+            char v[256];
+            rocfft_get_version_string(v);
+			std::cout << "version " << v << std::endl;
 			return 0;
 		}
 

--- a/clients/rider/rider.cpp
+++ b/clients/rider/rider.cpp
@@ -785,8 +785,8 @@ int main( int argc, char* argv[] )
 		if( vm.count( "version" ) )
 		{
             char v[256];
-            rocfft_get_version_string(v);
-			std::cout << "version " << v << std::endl;
+            rocfft_get_version_string(v, 256);
+            std::cout << "version " << v << std::endl;
 			return 0;
 		}
 

--- a/library/include/rocfft.h
+++ b/library/include/rocfft.h
@@ -195,6 +195,11 @@ ROCFFT_EXPORT rocfft_status rocfft_plan_description_set_data_layout(   rocfft_pl
                                                                     size_t in_strides_size, const size_t *in_strides, size_t in_distance,
                                                                     size_t out_strides_size, const size_t *out_strides, size_t out_distance );
 
+/*! @brief Get library version string
+ *
+ * @param[in, out] version string
+ */
+ROCFFT_EXPORT rocfft_status rocfft_get_version_string(char *version_string);
 
 #if 0
 /*! @brief Set devices in plan description

--- a/library/include/rocfft.h
+++ b/library/include/rocfft.h
@@ -197,9 +197,10 @@ ROCFFT_EXPORT rocfft_status rocfft_plan_description_set_data_layout(   rocfft_pl
 
 /*! @brief Get library version string
  *
- * @param[in, out] version string
+ * @param[in, out] buf buffer of version string
+ * @param[in] len the length of input string buffer
  */
-ROCFFT_EXPORT rocfft_status rocfft_get_version_string(char *version_string);
+ROCFFT_EXPORT rocfft_status rocfft_get_version_string(char *buf, size_t len);
 
 #if 0
 /*! @brief Set devices in plan description

--- a/library/src/plan.cpp
+++ b/library/src/plan.cpp
@@ -5,14 +5,19 @@
 #include <vector>
 #include <assert.h>
 #include <iostream>
-
+#include <sstream>
 #include "rocfft.h"
 #include "private.h"
 #include "plan.h"
 #include "repo.h"
 #include "radix_table.h"
 
-
+#define TO_STR2(x) #x
+#define TO_STR(x) TO_STR2(x)
+#define VERSION_STRING (TO_STR(rocfft_version_major) "." \
+                        TO_STR(rocfft_version_minor) "." \
+                        TO_STR(rocfft_version_patch) "." \
+                        TO_STR(rocfft_version_tweak))
 
 rocfft_status rocfft_plan_description_set_scale_float( rocfft_plan_description description, float scale )
 {
@@ -461,6 +466,12 @@ rocfft_status rocfft_plan_get_print( const rocfft_plan plan )
     return rocfft_status_success;
 }
 
+ROCFFT_EXPORT rocfft_status rocfft_get_version_string(char *version_string)
+{
+    std::string v(VERSION_STRING);
+    strcpy(version_string,  v.c_str());
+    return rocfft_status_success;
+}
 
 std::string PrintScheme(ComputeScheme cs)
 {

--- a/library/src/plan.cpp
+++ b/library/src/plan.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 #include <assert.h>
 #include <iostream>
-#include <sstream>
+
 #include "rocfft.h"
 #include "private.h"
 #include "plan.h"
@@ -466,10 +466,14 @@ rocfft_status rocfft_plan_get_print( const rocfft_plan plan )
     return rocfft_status_success;
 }
 
-ROCFFT_EXPORT rocfft_status rocfft_get_version_string(char *version_string)
+ROCFFT_EXPORT rocfft_status rocfft_get_version_string(char *buf, size_t len)
 {
     std::string v(VERSION_STRING);
-    strcpy(version_string,  v.c_str());
+    if (buf == NULL)
+        return rocfft_status_failure;
+    size_t count = std::min(len-1, v.length());
+    memcpy(buf, v.c_str(), count);
+    *(buf + count) = '\0';
     return rocfft_status_success;
 }
 


### PR DESCRIPTION
Summary of proposed changes:
Enabled versioning with git hash tag and added version string function.
The build option "PARSE_VERSION" comes from https://github.com/RadeonOpenCompute/rocm-cmake/blob/master/share/rocm/cmake/ROCMSetupVersion.cmake , just not be enabled.
