### PR TITLE
dropping cmake3 in favor of cmake found on centos7

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ install_packages( )
 
   # dependencies needed for rocfft and clients to build
   local library_dependencies_ubuntu=( "make" "cmake-curses-gui" "hip_hcc" "pkg-config" )
-  local library_dependencies_centos=( "epel-release" "make" "cmake3" "hip_hcc" "gcc-c++" )
+  local library_dependencies_centos=( "epel-release" "make" "cmake" "hip_hcc" "gcc-c++" )
   local library_dependencies_fedora=( "make" "cmake" "hip_hcc" "gcc-c++" "libcxx-devel" "rpm-build" )
 
   if [[ "${build_cuda}" == true ]]; then
@@ -266,7 +266,7 @@ cmake_executable=cmake
 
 case "${ID}" in
   centos|rhel)
-  cmake_executable=cmake3
+  cmake_executable=cmake
   ;;
 esac
 


### PR DESCRIPTION
Summary of proposed changes:
-  dropping `cmake3` in favor of `cmake` because centos7 (7.4.1708 in my case) does not install `cmake3` from the repos
