### PR TITLE
create stub folder that contains a minimal example on how to use rocfft

### DIFF
--- a/docs/samples/CMakeLists.txt
+++ b/docs/samples/CMakeLists.txt
@@ -7,17 +7,21 @@ find_package(hip)
 find_package(rocfft)
 
 add_executable(complex_forward_1d complex_forward_1d.cpp)
-target_compile_features( complex_forward_1d PRIVATE cxx_static_assert cxx_nullptr cxx_lambdas cxx_auto_type )
+#target_compile_features( complex_forward_1d PRIVATE cxx_static_assert cxx_nullptr cxx_lambdas cxx_auto_type )
 target_link_libraries( complex_forward_1d PRIVATE roc::rocfft hip::hip_hcc )
 target_include_directories( complex_forward_1d PRIVATE ${rocfft_INCLUDE_DIR} )
+set_target_properties( complex_forward_1d PROPERTIES
+  CXX_STANDARD_REQUIRED ON)
+set_target_properties( complex_forward_1d PROPERTIES
+  CXX_STANDARD 14)
 
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
   target_compile_options( complex_forward_1d PRIVATE -Wno-unused-command-line-argument )
+  set_target_properties( complex_forward_1d PROPERTIES
+    CXX_EXTENSIONS OFF)
 
-  set_target_properties( complex_forward_1d PROPERTIES CXX_EXTENSIONS OFF)
-  
   # foreach( target ${AMDGPU_TARGETS} )
   #   target_link_libraries( rocfft-selftest PRIVATE --amdgpu-target=${target} )
   # endforeach( )

--- a/docs/samples/CMakeLists.txt
+++ b/docs/samples/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(hip)
 find_package(rocfft)
 
 add_executable(complex_forward_1d complex_forward_1d.cpp)
-#target_compile_features( complex_forward_1d PRIVATE cxx_static_assert cxx_nullptr cxx_lambdas cxx_auto_type )
 target_link_libraries( complex_forward_1d PRIVATE roc::rocfft hip::hip_hcc )
 target_include_directories( complex_forward_1d PRIVATE ${rocfft_INCLUDE_DIR} )
 set_target_properties( complex_forward_1d PROPERTIES

--- a/docs/samples/CMakeLists.txt
+++ b/docs/samples/CMakeLists.txt
@@ -1,0 +1,23 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
+
+# project name
+PROJECT(rocfft_samples CXX)
+
+find_package(hip)
+find_package(rocfft)
+
+add_executable(complex_forward_1d complex_forward_1d.cpp)
+target_compile_features( complex_forward_1d PRIVATE cxx_static_assert cxx_nullptr cxx_lambdas cxx_auto_type )
+target_link_libraries( complex_forward_1d PRIVATE roc::rocfft hip::hip_hcc )
+target_include_directories( complex_forward_1d PRIVATE ${rocfft_INCLUDE_DIR} )
+message("!! ${rocfft_INCLUDE_DIR}")
+
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+  # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
+  # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
+  target_compile_options( complex_forward_1d PRIVATE -Wno-unused-command-line-argument )
+
+  # foreach( target ${AMDGPU_TARGETS} )
+  #   target_link_libraries( rocfft-selftest PRIVATE --amdgpu-target=${target} )
+  # endforeach( )
+endif( )

--- a/docs/samples/CMakeLists.txt
+++ b/docs/samples/CMakeLists.txt
@@ -10,13 +10,14 @@ add_executable(complex_forward_1d complex_forward_1d.cpp)
 target_compile_features( complex_forward_1d PRIVATE cxx_static_assert cxx_nullptr cxx_lambdas cxx_auto_type )
 target_link_libraries( complex_forward_1d PRIVATE roc::rocfft hip::hip_hcc )
 target_include_directories( complex_forward_1d PRIVATE ${rocfft_INCLUDE_DIR} )
-message("!! ${rocfft_INCLUDE_DIR}")
 
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
   target_compile_options( complex_forward_1d PRIVATE -Wno-unused-command-line-argument )
 
+  set_target_properties( complex_forward_1d PROPERTIES CXX_EXTENSIONS OFF)
+  
   # foreach( target ${AMDGPU_TARGETS} )
   #   target_link_libraries( rocfft-selftest PRIVATE --amdgpu-target=${target} )
   # endforeach( )

--- a/docs/samples/README.md
+++ b/docs/samples/README.md
@@ -1,0 +1,10 @@
+# Samples to demo using rocfft
+
+## `complex_forward_1d`
+
+``` bash
+$ mkdir build
+$ cmake ..
+$ make
+```
+

--- a/docs/samples/complex_forward_1d.cpp
+++ b/docs/samples/complex_forward_1d.cpp
@@ -1,7 +1,8 @@
 #include <stdio.h>
 #include <vector>
 #include <iostream>
-#include <math.h>
+#include <algorithm>
+#include <cmath>
 #include <hip/hip_runtime_api.h>
 #include "rocfft.h"
 
@@ -47,10 +48,18 @@ int main()
     // Copy result back to host
     std::vector<float2> y(N);
     hipMemcpy(&y[0], x, Nbytes, hipMemcpyDeviceToHost);
-
     hipFree(x);
 
     rocfft_cleanup();
+
+    for( size_t i = 0;i < N;++i){
+        if(std::abs( cx[i].x - y[i].x ) < 1e-5){
+            std::cerr << "Error - unexpected matching element: observed " << y[i].x << ", expected " <<  cx[i].x << std::endl;
+            return 1;
+        }
+    }
+
+    std::cout << "complex forward 1d - OK!" << std::endl;
 
     return 0;
 }

--- a/docs/samples/complex_forward_1d.cpp
+++ b/docs/samples/complex_forward_1d.cpp
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <vector>
+#include <iostream>
+#include <math.h>
+#include <hip/hip_runtime_api.h>
+#include "rocfft.h"
+
+
+int main()
+{
+    // For size N <= 4096
+    const size_t N = 16;
+
+    std::vector<float2> cx(N);
+
+    for (size_t i = 0; i < N; i++)
+    {
+        cx[i].x = (i%3) - (i%7);
+        cx[i].y = 0;
+    }
+
+    // rocfft gpu compute
+    // ========================================
+
+    rocfft_setup();
+
+    size_t Nbytes = N * sizeof(float2);
+
+    // Create HIP device object.
+    float2 *x;
+    hipMalloc(&x, Nbytes);
+
+    //  Copy data to device
+    hipMemcpy(x, &cx[0], Nbytes, hipMemcpyHostToDevice);
+
+    // Create plan
+    rocfft_plan plan = NULL;
+    size_t length = N;
+    rocfft_plan_create(&plan, rocfft_placement_inplace, rocfft_transform_type_complex_forward, rocfft_precision_single, 1, &length, 1, NULL);
+
+    // Execute plan
+    rocfft_execute(plan, (void**)&x, NULL, NULL);
+
+    // Destroy plan
+    rocfft_plan_destroy(plan);
+
+    // Copy result back to host
+    std::vector<float2> y(N);
+    hipMemcpy(&y[0], x, Nbytes, hipMemcpyDeviceToHost);
+
+    hipFree(x);
+
+    rocfft_cleanup();
+
+    return 0;
+}


### PR DESCRIPTION
Summary of proposed changes:
-  create a folder `samples` insides the `docs`
-  `samples` contains examples for clients to rocfft (which doesn't depend on boost, fftw, ...)
-  added minimal documentation on how to compile the sample
