### PR TITLE
Support build with hip-clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,11 @@ project( rocfft LANGUAGES CXX )
 # ########################################################################
 # Main
 # ########################################################################
-
-if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
+set( USE_HIP_CLANG OFF CACHE BOOL "Use hip-clang to build for amdgpu" )
+if( USE_HIP_CLANG )
+  message( STATUS "Use hip-clang to build for amdgpu backend" )
+  set( HIP_PLATFORM "hip-clang" )
+elseif( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
   # For now, we assume hipcc compiler means to compile for CUDA backend
   message( STATUS "HIPCC compiler detected; CUDA backend selected" )
 

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,7 @@ function display_help()
   echo "    [-c|--clients] build library clients too (combines with -i & -d)"
   echo "    [-g|--debug] -DCMAKE_BUILD_TYPE=Debug (default is =Release)"
   echo "    [--cuda] build library for cuda backend"
+  echo "    [--hip-clang] build library for amdgpu backend using hip-clang"
 }
 
 # This function is helpful for dockerfiles that do not have sudo installed, but the default user is root
@@ -204,7 +205,7 @@ build_release=true
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,cuda --options hicgd -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,cuda,hip-clang --options hicgd -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -237,6 +238,9 @@ while true; do
         shift ;;
     --cuda)
         build_cuda=true
+        shift ;;
+    --hip-clang)
+        build_hip_clang=true
         shift ;;
     --prefix)
         install_prefix=${2}
@@ -316,8 +320,12 @@ pushd .
   fi
 
   compiler="hcc"
-  if [[ "${build_cuda}" == true ]]; then
+  if [[ "${build_cuda}" == true || "${build_hip_clang}" == true ]]; then
     compiler="hipcc"
+  fi
+
+  if [[ "${build_hip_clang}" == true ]]; then
+    cmake_common_options="${cmake_common_options} -DUSE_HIP_CLANG=ON"
   fi
 
   # On ROCm platforms, hcc compiler can build everything

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -27,7 +27,7 @@ endfunction( )
 function( target_link_libraries target_name )
   # hipcc takes care of finding hip library dependencies internally; remove
   # explicit mentions of them so cmake doesn't complain on nvcc path
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" AND NOT USE_HIP_CLANG)
     foreach( link_library ${ARGN} )
       if( (link_library MATCHES "^hip::|^hcc::") )
       else( )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -66,7 +66,7 @@ target_link_libraries( rocfft PRIVATE hip::hip_hcc hip::hip_device hcc::hccshare
 endif()
 target_link_libraries( rocfft PRIVATE rocfft-device )
 
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
   target_compile_options( rocfft PRIVATE -Wno-unused-command-line-argument )

--- a/library/src/device/CMakeLists.txt
+++ b/library/src/device/CMakeLists.txt
@@ -83,7 +83,7 @@ if(HIP_PLATFORM STREQUAL "nvcc")
     target_compile_options( rocfft-device PRIVATE "-gencode arch=compute_50,code=sm_50 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_30,code=sm_30" )
 endif()
 
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
   target_compile_options( rocfft-device PRIVATE -Wno-unused-command-line-argument )


### PR DESCRIPTION
Let's merge Sam's hip-clang change into develop. This allows hip-clang to be usable on develop branch.

Summary of proposed changes:
-  Add option --hip-clang to install.sh.
-  Made changes to cmake files for hip-clang.
