### PR TITLE
HIP-Clang needs HIP_COMPILER as clang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -325,7 +325,7 @@ pushd .
   fi
 
   if [[ "${build_hip_clang}" == true ]]; then
-    cmake_common_options="${cmake_common_options} -DUSE_HIP_CLANG=ON"
+    cmake_common_options="${cmake_common_options} -DUSE_HIP_CLANG=ON -DHIP_COMPILER=clang"
   fi
 
   # On ROCm platforms, hcc compiler can build everything


### PR DESCRIPTION
resolves unknown argument -hc for HIP-Clang path.

Summary of proposed changes:
-  Add -DHIP_COMPILER=clang to cmake options or HIP-Clang path

This is required for Jenkins. Could this be merged into master branch? Thank you