### PR TITLE
CentOS support added

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,7 @@ rocFFTCI:
             command = """#!/usr/bin/env bash
                     set -x
                     cd ${project.paths.project_build_prefix}/build/release/clients/staging
-                    sudo LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocfft-test --gtest_output=xml --gtest_color=yes
+                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG sudo ./rocfft-test --gtest_output=xml --gtest_color=yes
                 """
         }
         else

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,10 +32,10 @@ rocFFTCI:
 
     def rocfft = new rocProject('rocfft')
     // customize for project
-    rocfft.paths.build_command = './install.sh -cd'
+    rocfft.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx906 && centos7'], rocfft)
+    def nodes = new dockerNodes(['gfx906 && centos7', 'gfx900'], rocfft)
 
     boolean formatCheck = false
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ rocFFTCI:
                     make package
                     rm -rf package && mkdir -p package
                     mv *.rpm package/
-                    rpm -c package/*.rpm
+                    rpm -qlp package/*.rpm
                 """
 
             platform.runCommand(this, command)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,7 @@ rocFFTCI:
         project.paths.construct_build_prefix()
         def command = """#!/usr/bin/env bash
                   set -x
+                  id
                   cd ${project.paths.project_build_prefix}
                   LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=${project.compiler.compiler_path} ${project.paths.build_command}
                 """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ rocFFTCI:
     rocfft.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx906&&centOS'], rocfft)
+    def nodes = new dockerNodes(['gfx906&&centOS7'], rocfft)
 
     boolean formatCheck = false
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,6 @@ rocFFTCI:
         project.paths.construct_build_prefix()
         def command = """#!/usr/bin/env bash
                   set -x
-                  id
                   cd ${project.paths.project_build_prefix}
                   LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=${project.compiler.compiler_path} ${project.paths.build_command}
                 """
@@ -59,13 +58,24 @@ rocFFTCI:
         platform, project->
 
         def command
-
-        command = """#!/usr/bin/env bash
-              set -x
-              cd ${project.paths.project_build_prefix}/build/release/clients/staging
-              LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocfft-test --gtest_output=xml --gtest_color=yes
-          """
-
+        
+        if(platform.jenkinsLabel.contains('centos'))
+        {
+            command = """#!/usr/bin/env bash
+                    set -x
+                    cd ${project.paths.project_build_prefix}/build/release/clients/staging
+                    sudo LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocfft-test --gtest_output=xml --gtest_color=yes
+                """
+        }
+        else
+        {
+            command = """#!/usr/bin/env bash
+                    set -x
+                    cd ${project.paths.project_build_prefix}/build/release/clients/staging
+                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocfft-test --gtest_output=xml --gtest_color=yes
+                """
+        }
+        
         platform.runCommand(this, command)
         junit "${project.paths.project_build_prefix}/build/release/clients/staging/*.xml"
     }
@@ -85,7 +95,7 @@ rocFFTCI:
                     rm -rf package && mkdir -p package
                     mv *.rpm package/
                     rpm -c package/*.rpm
-                    """
+                """
 
             platform.runCommand(this, command)
             platform.archiveArtifacts(this, """${project.paths.project_build_prefix}/build/release/package/*.rpm""")        
@@ -99,7 +109,7 @@ rocFFTCI:
                     rm -rf package && mkdir -p package
                     mv *.deb package/
                     dpkg -c package/*.deb
-                    """
+                """
 
             platform.runCommand(this, command)
             platform.archiveArtifacts(this, """${project.paths.project_build_prefix}/build/release/package/*.deb""")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ rocFFTCI:
 
         def command 
         
-        if(platform.jenkinsLabel.contains('centos')
+        if(platform.jenkinsLabel.contains('centos'))
         {
             command = """
                     set -x

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 // This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
-@Library('rocJenkins@clang9') _
+@Library('rocJenkins@centos') _
 
 // This is file for internal AMD use.
 // If you are interested in running your own Jenkins, please raise a github issue for assistance.
@@ -35,9 +35,9 @@ rocFFTCI:
     rocfft.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx900', 'gfx906'], rocfft)
+    def nodes = new dockerNodes(['gfx900', 'gfx906&&centOS'], rocfft)
 
-    boolean formatCheck = true
+    boolean formatCheck = false
 
     def compileCommand =
     {
@@ -73,17 +73,36 @@ rocFFTCI:
     {
         platform, project->
 
-        def command = """
-                      set -x
-                      cd ${project.paths.project_build_prefix}/build/release
-                      make package
-                      rm -rf package && mkdir -p package
-                      mv *.deb package/
-                      dpkg -c package/*.deb
-                      """
+        def command 
+        
+        if(platform.jenkinsLabel.contains('centos')
+        {
+            command = """
+                    set -x
+                    cd ${project.paths.project_build_prefix}/build/release
+                    make package
+                    rm -rf package && mkdir -p package
+                    mv *.rpm package/
+                    rpm -c package/*.rpm
+                    """
 
-        platform.runCommand(this, command)
-        platform.archiveArtifacts(this, """${project.paths.project_build_prefix}/build/release/package/*.deb""")
+            platform.runCommand(this, command)
+            platform.archiveArtifacts(this, """${project.paths.project_build_prefix}/build/release/package/*.rpm""")        
+        }
+        else
+        {
+            command = """
+                    set -x
+                    cd ${project.paths.project_build_prefix}/build/release
+                    make package
+                    rm -rf package && mkdir -p package
+                    mv *.deb package/
+                    dpkg -c package/*.deb
+                    """
+
+            platform.runCommand(this, command)
+            platform.archiveArtifacts(this, """${project.paths.project_build_prefix}/build/release/package/*.deb""")
+        }
     }
 
     buildProject(rocfft, formatCheck, nodes.dockerArray, compileCommand, testCommand, packageCommand)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ rocFFTCI:
     rocfft.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx906&&centos7'], rocfft)
+    def nodes = new dockerNodes(['gfx906 centos7'], rocfft)
 
     boolean formatCheck = false
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ rocFFTCI:
     rocfft.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx906,centos7'], rocfft)
+    def nodes = new dockerNodes(['gfx906 && centos7'], rocfft)
 
     boolean formatCheck = false
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ rocFFTCI:
     rocfft.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx900', 'gfx906&&centOS'], rocfft)
+    def nodes = new dockerNodes(['gfx906&&centOS'], rocfft)
 
     boolean formatCheck = false
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ rocFFTCI:
 
     def rocfft = new rocProject('rocfft')
     // customize for project
-    rocfft.paths.build_command = './install.sh -c'
+    rocfft.paths.build_command = './install.sh -cd'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(['gfx906 && centos7'], rocfft)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ rocFFTCI:
     rocfft.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx906 centos7'], rocfft)
+    def nodes = new dockerNodes(['gfx906,centos7'], rocfft)
 
     boolean formatCheck = false
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ rocFFTCI:
     rocfft.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx906&&centOS7'], rocfft)
+    def nodes = new dockerNodes(['gfx906&&centos7'], rocfft)
 
     boolean formatCheck = false
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ rocFFTCI:
 
     def rocfft = new rocProject('rocfft')
     // customize for project
-    rocfft.paths.build_command = './install.sh -cd'
+    rocfft.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(['gfx906 && centos7'], rocfft)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 // This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
-@Library('rocJenkins') _
+@Library('rocJenkins@centos') _
 
 // This is file for internal AMD use.
 // If you are interested in running your own Jenkins, please raise a github issue for assistance.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 // This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
-@Library('rocJenkins') _
+@Library('rocJenkins@clang9') _
 
 // This is file for internal AMD use.
 // If you are interested in running your own Jenkins, please raise a github issue for assistance.
@@ -37,7 +37,7 @@ rocFFTCI:
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(['gfx906 && centos7', 'gfx900'], rocfft)
 
-    boolean formatCheck = false
+    boolean formatCheck = true
 
     def compileCommand =
     {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 // This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
-@Library('rocJenkins@centos') _
+@Library('rocJenkins') _
 
 // This is file for internal AMD use.
 // If you are interested in running your own Jenkins, please raise a github issue for assistance.

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -2,9 +2,9 @@
 ARG base_image
 
 FROM ${base_image}
-LABEL maintainer="saad.rahim@amd"
+LABEL maintainer="akila.premachandra@amd.com"
 
-ARG user_uid=0
+ARG user_uid
 
 # Install dependent packages
 # Dependencies:

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -38,9 +38,9 @@ RUN scl enable devtoolset-7 bash
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-RUN useradd --create-home -u ${user_uid} -o -G sudo --shell /bin/bash jenkins && \
+RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
     mkdir -p /etc/sudoers.d/ && \
-    echo '%sudo   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
+    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
 
 ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
 

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -6,14 +6,14 @@ LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
 
+RUN chmod 644 /etc/sudoers && chmod 644 /etc/passwd && chmod 644 /etc/group \
+    && chmod 644 /etc/shadow
+
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
 RUN useradd -u ${user_uid} -o -G root --shell /bin/bash jenkins && \
-    echo '%root   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
-
-RUN chmod 644 /etc/sudoers && chmod 644 /etc/passwd && chmod 644 /etc/group \
-    && chmod 644 /etc/shadow
+    echo '%jenkins   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
 # Install dependent packages
 # Dependencies:

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -6,14 +6,14 @@ LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
 
-RUN chmod 644 /etc/sudoers && chmod 644 /etc/passwd && chmod 644 /etc/group \
-    && chmod 644 /etc/shadow
-
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
 RUN useradd -u ${user_uid} -o -G root --shell /bin/bash jenkins && \
     echo '%jenkins   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+
+RUN chmod 644 /etc/sudoers && chmod 644 /etc/passwd && chmod 644 /etc/group \
+    && chmod 644 /etc/shadow
 
 # Install dependent packages
 # Dependencies:

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -32,6 +32,9 @@ RUN yum -y update && yum install -y \
     yum -y clean all && \
     rm -rf /var/lib/apt/lists/*
 
+#Enable devtoolset-7 for CentOS, needed for updated packages
+RUN scl enable devtoolset-7 bash
+
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -12,7 +12,8 @@ ARG user_uid
 RUN useradd -u ${user_uid} -o -G root --shell /bin/bash jenkins && \
     echo '%root   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
-RUN chmod 644 /etc/*
+RUN chmod 644 /etc/sudoers && chmod 644 /etc/passwd && chmod 644 /etc/group \
+    && chmod 644 /etc/shadow
 
 # Install dependent packages
 # Dependencies:

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -9,11 +9,8 @@ ARG user_uid
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-RUN useradd -u ${user_uid} -o -G root --shell /bin/bash jenkins && \
-    echo '%jenkins   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
-
-RUN chmod 644 /etc/sudoers && chmod 644 /etc/passwd && chmod 644 /etc/group \
-    && chmod 644 /etc/shadow
+RUN useradd -u ${user_uid} -o -G root && \
+    echo '%root   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
 # Install dependent packages
 # Dependencies:
@@ -23,8 +20,7 @@ RUN chmod 644 /etc/sudoers && chmod 644 /etc/passwd && chmod 644 /etc/group \
 # * rocfft-bench: libboost-program-options-dev
 # * libhsakmt.so: libnuma1
 RUN yum -y update && yum -y group install "Development Tools" \
-    && yum -y group install "Additional Development" && \
-    yum -y clean all 
+    && yum -y clean all 
 
 RUN yum -y update && yum install -y \
     sudo \
@@ -34,10 +30,11 @@ RUN yum -y update && yum install -y \
     git \
     cmake3 \
     fftw-devel \
-    clang-format-3.8 \
+    llvm-toolset-7-git-clang-format \
     python2.7 \
     python-yaml \
     devtoolset-7-gcc-gfortran \
+    gcc-gfortran \
     boost-devel\
     numactl-libs \
     && \

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -1,11 +1,11 @@
 # Parameters related to building hip
-USER root
 ARG base_image
 
 FROM ${base_image}
 LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
+USER root
 
 # Install dependent packages
 # Dependencies:

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -1,4 +1,5 @@
 # Parameters related to building hip
+USER root
 ARG base_image
 
 FROM ${base_image}
@@ -36,7 +37,6 @@ RUN yum -y update && yum install -y \
 
 RUN scl enable devtoolset-7 bash
 
-USER root
 RUN chmod 440 /etc/sudoers
 
 # docker pipeline runs containers with particular uid

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -38,9 +38,7 @@ RUN scl enable devtoolset-7 bash
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
-    mkdir -p /etc/sudoers.d/ && \
-    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
+RUN RUN usermod -aG wheel ${user_uid}
 
 ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
 

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -27,10 +27,12 @@ RUN yum install -y \
     libcxx-devel \
     boost-devel\
     numactl-libs \
-    rpm-build \
+    rpm-build
 
+#RUN echo 'scl enable devtoolset-7 bash' >>/etc/skel/.bashrc
 
-RUN echo 'scl enable devtoolset-7 bash' >>/etc/bashrc
+RUN echo '#!/bin/bash' | tee /etc/profile.d/devtoolset7.sh && echo \
+    'source scl_source enable devtoolset-7' >>/etc/profile.d/devtoolset7.sh
 
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -5,7 +5,6 @@ FROM ${base_image}
 LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
-USER root
 
 # Install dependent packages
 # Dependencies:
@@ -37,12 +36,10 @@ RUN yum -y update && yum install -y \
 
 RUN scl enable devtoolset-7 bash
 
-RUN chmod 777 /etc/sudoers && chmod 777 /etc/passwd && chmod 777 /etc/group
+RUN chmod 440 /etc/sudoers && chmod 440 /etc/passwd && chmod 440 /etc/group
 
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
 RUN useradd -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
     echo '%wheel   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
-    
-USER 1001

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -6,10 +6,9 @@ LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
 
-RUN yum -y update && yum install -y \
+RUN yum install -y \
     sudo \
-    rocm* \
-    rocfft \
+    rock-dkms \
     centos-release-scl \
     devtoolset-7 \
     ca-certificates \
@@ -29,10 +28,9 @@ RUN yum -y update && yum install -y \
     boost-devel\
     numactl-libs \
     rpm-build \
-    && \
-    yum -y clean all 
 
-RUN scl enable devtoolset-7 bash
+
+RUN echo 'scl enable devtoolset-7 bash' >>/etc/bashrc
 
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
@@ -40,14 +38,3 @@ RUN scl enable devtoolset-7 bash
 RUN useradd --create-home -u ${user_uid} -o -G video --shell /bin/bash jenkins && \
     echo '%video ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd && \
     chmod 400 /etc/sudoers.d/sudo-nopasswd
-
-ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
-
-# Clone rocfft repo
-# Build client dependencies and install into /usr/local (LAPACK & GTEST)
-RUN mkdir -p ${ROCFFT_SRC_ROOT} && cd ${ROCFFT_SRC_ROOT} && \
-    git clone -b develop --depth=1 https://github.com/ROCmSoftwarePlatform/rocFFT . && \
-    mkdir -p build/deps && cd build/deps && \
-    cmake3 -DBUILD_BOOST=OFF ${ROCFFT_SRC_ROOT}/deps && \
-    make -j $(nproc) install && \
-    rm -rf ${ROCFFT_SRC_ROOT}

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -4,7 +4,7 @@ ARG base_image
 FROM ${base_image}
 LABEL maintainer="saad.rahim@amd"
 
-ARG user_uid
+#ARG user_uid=0
 
 # Install dependent packages
 # Dependencies:

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -38,10 +38,11 @@ RUN yum -y update && yum install -y \
 RUN scl enable devtoolset-7 bash
 
 RUN chmod 440 /etc/sudoers
-USER 1001
 
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
 RUN useradd -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
     echo '%wheel   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+    
+USER 1001

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -1,0 +1,51 @@
+# Parameters related to building hip
+ARG base_image
+
+FROM ${base_image}
+LABEL maintainer="saad.rahim@amd"
+
+ARG user_uid
+
+# Install dependent packages
+# Dependencies:
+# * hcc-config.cmake: pkg-config
+# * tensile: python2.7, python-yaml
+# * rocfft-test: gfortran, googletest
+# * rocfft-bench: libboost-program-options-dev
+# * libhsakmt.so: libnuma1
+RUN yum -y update && yum install -y \
+    sudo \
+    build-essential \
+    ca-certificates \
+    git \
+    make \
+    cmake \
+    libfftw3-dev \
+    clang-format-3.8 \
+    pkg-config \
+    python2.7 \
+    python-yaml \
+    gfortran \
+    libboost-program-options-dev \
+    libnuma1 \
+    && \
+    yum -y clean all && \
+    rm -rf /var/lib/apt/lists/*
+
+# docker pipeline runs containers with particular uid
+# create a jenkins user with this specific uid so it can use sudo priviledges
+# Grant any member of sudo group password-less sudo privileges
+RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
+    mkdir -p /etc/sudoers.d/ && \
+    echo '%sudo   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
+
+ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
+
+# Clone rocfft repo
+# Build client dependencies and install into /usr/local (LAPACK & GTEST)
+RUN mkdir -p ${ROCFFT_SRC_ROOT} && cd ${ROCFFT_SRC_ROOT} && \
+    git clone -b develop --depth=1 https://github.com/ROCmSoftwarePlatform/rocFFT . && \
+    mkdir -p build/deps && cd build/deps && \
+    cmake3 -DBUILD_BOOST=OFF ${ROCFFT_SRC_ROOT}/deps && \
+    make -j $(nproc) install && \
+    rm -rf ${ROCFFT_SRC_ROOT}

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -38,7 +38,6 @@ RUN scl enable devtoolset-7 bash
 
 USER root
 RUN chmod 440 /etc/sudoers
-USER user_uid
 
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -20,13 +20,13 @@ RUN yum -y update && yum install -y \
     git \
     make \
     cmake \
-    libfftw3-dev \
+    fftw-devel \
     clang-format-3.8 \
     pkg-config \
     python2.7 \
     python-yaml \
     gfortran \
-    libboost-program-options-dev \
+    boost-devel\
     libnuma1 \
     && \
     yum -y clean all && \

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -36,10 +36,11 @@ RUN yum -y update && yum install -y \
 
 RUN scl enable devtoolset-7 bash
 
+RUN chmod 644 /etc/sudoers && chmod 644 /etc/passwd && chmod 644 /etc/group \
+    && chmod 644 /etc/shadow
+
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-RUN useradd -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
-    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
-
-RUN chmod 555 /etc/sudoers && chmod 555 /etc/passwd && chmod 555 /etc/group
+RUN useradd -u ${user_uid} -o -G root --shell /bin/bash jenkins && \
+    echo '%root   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -5,7 +5,6 @@ FROM ${base_image}
 LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
-USER 0
 
 # Install dependent packages
 # Dependencies:
@@ -14,30 +13,35 @@ USER 0
 # * rocfft-test: gfortran, googletest
 # * rocfft-bench: libboost-program-options-dev
 # * libhsakmt.so: libnuma1
+RUN yum -y update && yum -y group install "Development Tools" \
+    && yum -y group install "Additional Development" && \
+    yum -y clean all 
+
 RUN yum -y update && yum install -y \
     sudo \
-    build-essential \
+    centos-release-scl \
+    devtoolset-7 \
     ca-certificates \
     git \
-    make \
-    cmake \
+    cmake3 \
     fftw-devel \
     clang-format-3.8 \
-    pkg-config \
     python2.7 \
     python-yaml \
-    gfortran \
+    devtoolset-7-gcc-gfortran \
     boost-devel\
-    libnuma1 \
+    numactl-libs \
     && \
     yum -y clean all 
+
+RUN scl enable devtoolset-7 bash
 
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-#   RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
-#    mkdir -p /etc/sudoers.d/ && \
-#    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
+RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
+    mkdir -p /etc/sudoers.d/ && \
+    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
 
 ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
 

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -38,9 +38,10 @@ RUN scl enable devtoolset-7 bash
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
 RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
-    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
+    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd && \
+    chmod 400 /etc/sudoers.d/sudo-nopasswd
 
-RUN usermod -aG wheel jenkins
+RUN usermod -aG video jenkins
 
 ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
 

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -38,7 +38,7 @@ RUN scl enable devtoolset-7 bash
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
+RUN useradd --create-home -u ${user_uid} -o -G sudo --shell /bin/bash jenkins && \
     mkdir -p /etc/sudoers.d/ && \
     echo '%sudo   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
 

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -5,6 +5,7 @@ FROM ${base_image}
 LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
+USER 0
 
 RUN yum -y update && yum install -y \
     sudo \
@@ -38,4 +39,4 @@ RUN scl enable devtoolset-7 bash
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
 RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
-    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -42,3 +42,14 @@ RUN echo '#!/bin/bash' | tee /etc/profile.d/devtoolset7.sh && echo \
 RUN useradd --create-home -u ${user_uid} -o -G video --shell /bin/bash jenkins && \
     echo '%video ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd && \
     chmod 400 /etc/sudoers.d/sudo-nopasswd
+    
+ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
+
+# Clone rocfft repo
+# Build client dependencies and install into /usr/local (LAPACK & GTEST)
+RUN mkdir -p ${ROCFFT_SRC_ROOT} && cd ${ROCFFT_SRC_ROOT} && \
+    git clone -b develop --depth=1 https://github.com/ROCmSoftwarePlatform/rocFFT . && \
+    mkdir -p build/deps && cd build/deps && \
+    cmake3 -DBUILD_BOOST=OFF ${ROCFFT_SRC_ROOT}/deps && \
+    make -j $(nproc) install && \
+    rm -rf ${ROCFFT_SRC_ROOT}

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -1,7 +1,4 @@
 # Parameters related to building hip
-ARG base_image
-
-FROM ${base_image}
 LABEL maintainer="saad.rahim@amd"
 
 ARG user_uid

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -36,10 +36,10 @@ RUN yum -y update && yum install -y \
 
 RUN scl enable devtoolset-7 bash
 
-RUN chmod 440 /etc/sudoers && chmod 440 /etc/passwd && chmod 440 /etc/group
-
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
 RUN useradd -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
     echo '%wheel   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+
+RUN chmod 555 /etc/sudoers && chmod 555 /etc/passwd && chmod 555 /etc/group

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -1,4 +1,7 @@
 # Parameters related to building hip
+ARG base_image
+
+FROM ${base_image}
 LABEL maintainer="saad.rahim@amd"
 
 ARG user_uid

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -5,7 +5,6 @@ FROM ${base_image}
 LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
-USER 0
 
 RUN yum -y update && yum install -y \
     sudo \
@@ -40,3 +39,16 @@ RUN scl enable devtoolset-7 bash
 # Grant any member of sudo group password-less sudo privileges
 RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
     echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
+
+RUN usermod -aG wheel jenkins
+
+ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
+
+# Clone rocfft repo
+# Build client dependencies and install into /usr/local (LAPACK & GTEST)
+RUN mkdir -p ${ROCFFT_SRC_ROOT} && cd ${ROCFFT_SRC_ROOT} && \
+    git clone -b develop --depth=1 https://github.com/ROCmSoftwarePlatform/rocFFT . && \
+    mkdir -p build/deps && cd build/deps && \
+    cmake3 -DBUILD_BOOST=OFF ${ROCFFT_SRC_ROOT}/deps && \
+    make -j $(nproc) install && \
+    rm -rf ${ROCFFT_SRC_ROOT}

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -19,6 +19,8 @@ RUN yum install -y \
     clang-devel \
     gcc-c++ \
     gcc-gfortran \
+    gtest-devel \
+    gtest \
     fftw-devel \
     pkgconfig \
     python27 \

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -4,7 +4,7 @@ ARG base_image
 FROM ${base_image}
 LABEL maintainer="saad.rahim@amd"
 
-#ARG user_uid=0
+ARG user_uid=0
 
 # Install dependent packages
 # Dependencies:

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -37,7 +37,7 @@ RUN yum -y update && yum install -y \
 
 RUN scl enable devtoolset-7 bash
 
-RUN chmod 440 /etc/sudoers
+RUN chmod 777 /etc/sudoers && chmod 777 /etc/passwd && chmod 777 /etc/group
 
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -9,7 +9,7 @@ ARG user_uid
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-RUN useradd -u ${user_uid} -o -G root && \
+RUN adduser -u ${user_uid} -o -G root && \
     echo '%root   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
 # Install dependent packages

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -36,20 +36,12 @@ RUN yum -y update && yum install -y \
 
 RUN scl enable devtoolset-7 bash
 
+USER root
+RUN chmod 440 /etc/sudoers
+USER user_uid
+
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
-    mkdir -p /etc/sudoers.d/ && \
-    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
-
-ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
-
-# Clone rocfft repo
-# Build client dependencies and install into /usr/local (LAPACK & GTEST)
-RUN mkdir -p ${ROCFFT_SRC_ROOT} && cd ${ROCFFT_SRC_ROOT} && \
-    git clone -b develop --depth=1 https://github.com/ROCmSoftwarePlatform/rocFFT . && \
-    mkdir -p build/deps && cd build/deps && \
-    cmake3 -DBUILD_BOOST=OFF ${ROCFFT_SRC_ROOT}/deps && \
-    make -j $(nproc) install && \
-    rm -rf ${ROCFFT_SRC_ROOT}
+RUN useradd -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
+    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -38,7 +38,9 @@ RUN scl enable devtoolset-7 bash
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-RUN RUN usermod -aG wheel ${user_uid}
+RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
+    mkdir -p /etc/sudoers.d/ && \
+    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
 
 ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
 

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -37,11 +37,9 @@ RUN scl enable devtoolset-7 bash
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
-    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd && \
+RUN useradd --create-home -u ${user_uid} -o -G video --shell /bin/bash jenkins && \
+    echo '%video ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd && \
     chmod 400 /etc/sudoers.d/sudo-nopasswd
-
-RUN usermod -aG video jenkins && usermod -aG wheel jenkins
 
 ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
 

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -6,38 +6,36 @@ LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
 
-# docker pipeline runs containers with particular uid
-# create a jenkins user with this specific uid so it can use sudo priviledges
-# Grant any member of sudo group password-less sudo privileges
-RUN adduser -u ${user_uid} -o -G root && \
-    echo '%root   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
-
-# Install dependent packages
-# Dependencies:
-# * hcc-config.cmake: pkg-config
-# * tensile: python2.7, python-yaml
-# * rocfft-test: gfortran, googletest
-# * rocfft-bench: libboost-program-options-dev
-# * libhsakmt.so: libnuma1
-RUN yum -y update && yum -y group install "Development Tools" \
-    && yum -y clean all 
-
 RUN yum -y update && yum install -y \
     sudo \
+    rocm* \
+    rocfft \
     centos-release-scl \
     devtoolset-7 \
     ca-certificates \
     git \
     cmake3 \
-    fftw-devel \
-    llvm-toolset-7-git-clang-format \
-    python2.7 \
-    python-yaml \
-    devtoolset-7-gcc-gfortran \
+    make \
+    clang \
+    clang-devel \
+    gcc-c++ \
     gcc-gfortran \
+    fftw-devel \
+    pkgconfig \
+    python27 \
+    python34 \
+    PyYAML \
+    libcxx-devel \
     boost-devel\
     numactl-libs \
+    rpm-build \
     && \
     yum -y clean all 
 
 RUN scl enable devtoolset-7 bash
+
+# docker pipeline runs containers with particular uid
+# create a jenkins user with this specific uid so it can use sudo priviledges
+# Grant any member of sudo group password-less sudo privileges
+RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
+    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -5,6 +5,7 @@ FROM ${base_image}
 LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
+USER 0
 
 # Install dependent packages
 # Dependencies:
@@ -29,11 +30,7 @@ RUN yum -y update && yum install -y \
     boost-devel\
     libnuma1 \
     && \
-    yum -y clean all && \
-    rm -rf /var/lib/apt/lists/*
-
-#Enable devtoolset-7 for CentOS, needed for updated packages
-RUN scl enable devtoolset-7 bash
+    yum -y clean all 
 
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -35,9 +35,9 @@ RUN yum -y update && yum install -y \
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
-    mkdir -p /etc/sudoers.d/ && \
-    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
+#   RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
+#    mkdir -p /etc/sudoers.d/ && \
+#    echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
 
 ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
 

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -41,7 +41,7 @@ RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins &
     echo '%wheel   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd && \
     chmod 400 /etc/sudoers.d/sudo-nopasswd
 
-RUN usermod -aG video jenkins
+RUN usermod -aG video jenkins && usermod -aG wheel jenkins
 
 ARG ROCFFT_SRC_ROOT=/usr/local/src/rocFFT
 

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -6,6 +6,14 @@ LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
 
+# docker pipeline runs containers with particular uid
+# create a jenkins user with this specific uid so it can use sudo priviledges
+# Grant any member of sudo group password-less sudo privileges
+RUN useradd -u ${user_uid} -o -G root --shell /bin/bash jenkins && \
+    echo '%root   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+
+RUN chmod 644 /etc/*
+
 # Install dependent packages
 # Dependencies:
 # * hcc-config.cmake: pkg-config
@@ -35,12 +43,3 @@ RUN yum -y update && yum install -y \
     yum -y clean all 
 
 RUN scl enable devtoolset-7 bash
-
-RUN chmod 644 /etc/sudoers && chmod 644 /etc/passwd && chmod 644 /etc/group \
-    && chmod 644 /etc/shadow
-
-# docker pipeline runs containers with particular uid
-# create a jenkins user with this specific uid so it can use sudo priviledges
-# Grant any member of sudo group password-less sudo privileges
-RUN useradd -u ${user_uid} -o -G root --shell /bin/bash jenkins && \
-    echo '%root   ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -38,6 +38,7 @@ RUN yum -y update && yum install -y \
 RUN scl enable devtoolset-7 bash
 
 RUN chmod 440 /etc/sudoers
+USER 1001
 
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges

--- a/docker/dockerfile-install-centos
+++ b/docker/dockerfile-install-centos
@@ -1,0 +1,21 @@
+# Parameters related to building rocfft
+ARG base_image
+
+FROM ${base_image}
+LABEL maintainer="saad.rahim@amd"
+
+# Copy the rpm package of rocfft into the container from host
+COPY *.rpm /tmp/
+
+# Install the rpm package, and print out contents of expected changed locations
+RUN yum -y update && yum install -y\
+    /tmp/rocfft-*.rpm \
+  && rm -f /tmp/*.rpm \
+  && yum -y clean all \
+  && rm -rf /var/lib/apt/lists/* \
+  && printf "ls -la /etc/ld.so.conf.d/\n" && ls -la /etc/ld.so.conf.d/ \
+  && printf "ls -la /opt/rocm/include\n" && ls -la /opt/rocm/include \
+  && printf "ls -la /opt/rocm/lib\n" && ls -la /opt/rocm/lib \
+  && printf "ls -la /opt/rocm/lib/cmake\n" && ls -la /opt/rocm/lib/cmake \
+  && printf "ls -la /opt/rocm/rocfft/include\n" && ls -la /opt/rocm/rocfft/include \
+  && printf "ls -la /opt/rocm/rocfft/lib\n" && ls -la /opt/rocm/rocfft/lib

--- a/install.sh
+++ b/install.sh
@@ -26,15 +26,15 @@ function display_help()
 supported_distro( )
 {
     if [ -z ${ID+foo} ]; then
-	printf "supported_distro(): \$ID must be set\n"
-	exit 2
+        printf "supported_distro(): \$ID must be set\n"
+        exit 2
     fi
 
     case "${ID}" in
-	ubuntu|centos|rhel|fedora)
+        ubuntu|centos|rhel|fedora)
             true
             ;;
-	*)  printf "This script is currently supported on Ubuntu, CentOS, RHEL and Fedora\n"
+        *)  printf "This script is currently supported on Ubuntu, CentOS, RHEL and Fedora\n"
             exit 2
             ;;
     esac
@@ -45,7 +45,7 @@ supported_distro( )
 check_exit_code( )
 {
     if (( $? != 0 )); then
-	exit $?
+        exit $?
     fi
 }
 
@@ -59,13 +59,13 @@ check_install_dir() {
     while [[ ${dir} != ${lastdir}  ]]
     do
 	#echo ${dir}
-	if [ -d "${dir}" ]; then
-	    if [ -w ${dir} ]; then
-		indir_is_ok=0
-	    fi
-	    break
-	fi
-	dir="$(dirname "$dir")"
+        if [ -d "${dir}" ]; then
+            if [ -w ${dir} ]; then
+                indir_is_ok=0
+            fi
+            break
+        fi
+        dir="$(dirname "$dir")"
     done
     return ${indir_is_ok}
 }
@@ -77,11 +77,11 @@ elevate_if_not_root( )
     local uid=$(id -u)
 
     if (( ${uid} )); then
-	sudo $@
-	check_exit_code
+        sudo $@
+        check_exit_code
     else
-	$@
-	check_exit_code
+        $@
+        check_exit_code
     fi
 }
 
@@ -91,10 +91,10 @@ install_apt_packages( )
 {
     package_dependencies=("$@")
     for package in "${package_dependencies[@]}"; do
-	if [[ $(dpkg-query --show --showformat='${db:Status-Abbrev}\n' ${package} 2> /dev/null | grep -q "ii"; echo $?) -ne 0 ]]; then
-	    printf "\033[32mInstalling \033[33m${package}\033[32m from distro package manager\033[0m\n"
-	    elevate_if_not_root apt install -y --no-install-recommends ${package}
-	fi
+        if [[ $(dpkg-query --show --showformat='${db:Status-Abbrev}\n' ${package} 2> /dev/null | grep -q "ii"; echo $?) -ne 0 ]]; then
+            printf "\033[32mInstalling \033[33m${package}\033[32m from distro package manager\033[0m\n"
+            elevate_if_not_root apt install -y --no-install-recommends ${package}
+        fi
     done
 }
 
@@ -104,10 +104,10 @@ install_yum_packages( )
 {
     package_dependencies=("$@")
     for package in "${package_dependencies[@]}"; do
-	if [[ $(yum list installed ${package} &> /dev/null; echo $? ) -ne 0 ]]; then
-	    printf "\033[32mInstalling \033[33m${package}\033[32m from distro package manager\033[0m\n"
-	    elevate_if_not_root yum -y --nogpgcheck install ${package}
-	fi
+        if [[ $(yum list installed ${package} &> /dev/null; echo $? ) -ne 0 ]]; then
+            printf "\033[32mInstalling \033[33m${package}\033[32m from distro package manager\033[0m\n"
+            elevate_if_not_root yum -y --nogpgcheck install ${package}
+        fi
     done
 }
 
@@ -117,10 +117,10 @@ install_dnf_packages( )
 {
     package_dependencies=("$@")
     for package in "${package_dependencies[@]}"; do
-	if [[ $(dnf list installed ${package} &> /dev/null; echo $? ) -ne 0 ]]; then
-	    printf "\033[32mInstalling \033[33m${package}\033[32m from distro package manager\033[0m\n"
-	    elevate_if_not_root dnf install -y ${package}
-	fi
+        if [[ $(dnf list installed ${package} &> /dev/null; echo $? ) -ne 0 ]]; then
+            printf "\033[32mInstalling \033[33m${package}\033[32m from distro package manager\033[0m\n"
+            elevate_if_not_root dnf install -y ${package}
+        fi
     done
 }
 
@@ -130,13 +130,13 @@ install_dnf_packages( )
 install_packages( )
 {
     if [ -z ${ID+foo} ]; then
-	printf "install_packages(): \$ID must be set\n"
-	exit 2
+        printf "install_packages(): \$ID must be set\n"
+        exit 2
     fi
 
     if [ -z ${build_clients+foo} ]; then
-	printf "install_packages(): \$build_clients must be set\n"
-	exit 2
+        printf "install_packages(): \$build_clients must be set\n"
+        exit 2
     fi
 
     # dependencies needed for rocfft and clients to build
@@ -145,10 +145,10 @@ install_packages( )
     local library_dependencies_fedora=( "make" "cmake" "hip_hcc" "gcc-c++" "libcxx-devel" "rpm-build" )
 
     if [[ "${build_cuda}" == true ]]; then
-	# Ideally, this could be cuda-cufft-dev, but the package name has a version number in it
-	library_dependencies_ubuntu+=( "cuda" )
-	library_dependencies_centos+=( "" ) # how to install cuda on centos?
-	library_dependencies_fedora+=( "" ) # how to install cuda on fedora?
+        # Ideally, this could be cuda-cufft-dev, but the package name has a version number in it
+        library_dependencies_ubuntu+=( "cuda" )
+        library_dependencies_centos+=( "" ) # how to install cuda on centos?
+        library_dependencies_fedora+=( "" ) # how to install cuda on fedora?
     fi
 
     local client_dependencies_ubuntu=( "libfftw3-dev" "libboost-program-options-dev" )
@@ -156,36 +156,36 @@ install_packages( )
     local client_dependencies_fedora=( "fftw-devel" "boost-devel" )
 
     case "${ID}" in
-	ubuntu)
-	    # elevate_if_not_root apt update
-	    install_apt_packages "${library_dependencies_ubuntu[@]}"
+        ubuntu)
+            # elevate_if_not_root apt update
+            install_apt_packages "${library_dependencies_ubuntu[@]}"
 
-	    if [[ "${build_clients}" == true ]]; then
-		install_apt_packages "${client_dependencies_ubuntu[@]}"
-	    fi
-	    ;;
+            if [[ "${build_clients}" == true ]]; then
+            install_apt_packages "${client_dependencies_ubuntu[@]}"
+            fi
+            ;;
 
-	centos|rhel)
-	    # elevate_if_not_root yum -y update
-	    install_yum_packages "${library_dependencies_centos[@]}"
+        centos|rhel)
+            # elevate_if_not_root yum -y update
+            install_yum_packages "${library_dependencies_centos[@]}"
 
-	    if [[ "${build_clients}" == true ]]; then
-		install_yum_packages "${client_dependencies_centos[@]}"
-	    fi
-	    ;;
+            if [[ "${build_clients}" == true ]]; then
+                install_yum_packages "${client_dependencies_centos[@]}"
+            fi
+            ;;
 
-	fedora)
-	    # elevate_if_not_root dnf -y update
-	    install_dnf_packages "${library_dependencies_fedora[@]}"
+        fedora)
+            # elevate_if_not_root dnf -y update
+            install_dnf_packages "${library_dependencies_fedora[@]}"
 
-	    if [[ "${build_clients}" == true ]]; then
-		install_dnf_packages "${client_dependencies_fedora[@]}"
-	    fi
-	    ;;
-	*)
-	    echo "This script is currently supported on Ubuntu, CentOS, RHEL and Fedora"
-	    exit 2
-	    ;;
+            if [[ "${build_clients}" == true ]]; then
+                install_dnf_packages "${client_dependencies_fedora[@]}"
+            fi
+            ;;
+        *)
+            echo "This script is currently supported on Ubuntu, CentOS, RHEL and Fedora"
+            exit 2
+            ;;
     esac
 }
 
@@ -246,34 +246,34 @@ eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
-	-h|--help)
+        -h|--help)
             display_help
             exit 0
             ;;
-	-i|--install)
+        -i|--install)
             install_package=true
             shift ;;
-	-d|--dependencies)
+        -d|--dependencies)
             install_dependencies=true
             shift ;;
-	-c|--clients)
+        -c|--clients)
             build_clients=true
             shift ;;
-	-g|--debug)
+        -g|--debug)
             build_release=false
             shift ;;
-	--cuda)
+        --cuda)
             build_cuda=true
             shift ;;
-	--hip-clang)
+        --hip-clang)
             build_hip_clang=true
             shift ;;
-	--prefix)
-	    echo $2
+        --prefix)
+            echo $2
             install_prefix=${2}
             shift 2 ;;
-	--) shift ; break ;;
-	*)  echo "Unexpected command line parameter received; aborting";
+        --) shift ; break ;;
+        *)  echo "Unexpected command line parameter received; aborting";
             exit 1
             ;;
     esac
@@ -359,17 +359,17 @@ if [[ "${build_cuda}" == false ]]; then
 
     # Build library with AMD toolchain because of existense of device kernels
     if [[ "${build_clients}" == true ]]; then
-	CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX=${install_prefix} -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm ../..
+        CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX=${install_prefix} -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm ../..
     else
-	CXX=${compiler} ${cmake_executable} ${cmake_common_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX=${install_prefix} -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm ../..
+        CXX=${compiler} ${cmake_executable} ${cmake_common_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX=${install_prefix} -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm ../..
     fi
     check_exit_code
     make -j$(nproc)
     check_exit_code
     if ( check_install_dir ${install_prefix} ) ; then
-	make install
+        make install
     else
-	elevate_if_not_root make install
+        elevate_if_not_root make install
     fi
     check_exit_code
 
@@ -393,18 +393,18 @@ else
     make -j$(nproc)
     check_exit_code
     if ( check_install_dir ${install_prefix} ) ; then
-	make install
+        make install
     else
-	elevate_if_not_root make install
+        elevate_if_not_root make install
     fi
     check_exit_code
     
     # Build cuda clients with default host compiler
     if [[ "${build_clients}" == true ]]; then
-	pushd clients
+        pushd clients
         ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCMAKE_PREFIX_PATH="$(pwd)/../rocfft-install;$(pwd)/../deps/deps-install" ../../../clients
         make -j$(nproc)
-	popd
+        popd
     fi
 fi
 
@@ -420,15 +420,15 @@ if [[ "${install_package}" == true ]]; then
         check_exit_code
     fi
     case "${ID}" in
-	ubuntu)
+        ubuntu)
             elevate_if_not_root dpkg -i rocfft-*.deb
-	    ;;
-	centos|rhel)
+            ;;
+        centos|rhel)
             elevate_if_not_root yum -y localinstall rocfft-*.rpm
-	    ;;
-	fedora)
+            ;;
+        fedora)
             elevate_if_not_root dnf install rocfft-*.rpm
-	    ;;
+            ;;
     esac
 
 fi


### PR DESCRIPTION
Summary of proposed changes:
- Passes CI: http://hsautil.amd.com/job/ROCmSoftwarePlatform/job/rocFFT/view/change-requests/job/PR-189/13/
- An upcoming merge of the rocJenkins/centos branch into develop will change this commit, so please don't merge this until that happens
- See the 2 new dockerfiles. Don't rename them, or else they don't work in shared libraries
- See Jenkinsfile for how to enable centOS support
- Jenkinsfile is currently configured to run in parallel on gfx900 architecture for Ubuntu, and gfx906 architecture for CentOS 
- For CentOS, please disable format check in the Jenkinsfile (for now). Right now, CentOS is running clang-format-3.8. There will be a format check failure if you enable it
- Must squash and  merge into 1 commit