### PR TITLE
New clang format file for rocm2.5

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,12 +23,14 @@ DisableFormat:   false
 Standard: Cpp11
 
 AccessModifierOffset: -4
-AlignAfterOpenBracket: true
+AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
-AlignEscapedNewlinesLeft: true
+AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
@@ -46,6 +48,7 @@ BinPackParameters: false
 BreakBeforeBraces: Custom
 # Control of individual brace wrapping cases
 BraceWrapping: {
+    AfterCaseLabel: 'true'
     AfterClass: 'true'
     AfterControlStatement: 'true'
     AfterEnum : 'true'
@@ -77,6 +80,7 @@ DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 IndentCaseLabels: false
+IndentPPDirectives: None
 #FixNamespaceComments: true
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: true
@@ -116,5 +120,4 @@ SortIncludes: true
 ReflowComments: false
 
 #IncludeBlocks: Preserve
-#IndentPPDirectives: AfterHash
 ---

--- a/.clang-format
+++ b/.clang-format
@@ -75,7 +75,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-#SpaceBeforeCpp11BracedList: false
+SpaceBeforeCpp11BracedList: false
 DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]

--- a/.clang-format
+++ b/.clang-format
@@ -23,14 +23,12 @@ DisableFormat:   false
 Standard: Cpp11
 
 AccessModifierOffset: -4
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: true
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
-AlignEscapedNewlines: Left
+AlignEscapedNewlinesLeft: true
 AlignOperands:   true
 AlignTrailingComments: false
-AllowAllArgumentsOnNextLine: true
-AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
@@ -48,7 +46,6 @@ BinPackParameters: false
 BreakBeforeBraces: Custom
 # Control of individual brace wrapping cases
 BraceWrapping: {
-    AfterCaseLabel: 'true'
     AfterClass: 'true'
     AfterControlStatement: 'true'
     AfterEnum : 'true'
@@ -80,7 +77,6 @@ DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 IndentCaseLabels: false
-IndentPPDirectives: None
 #FixNamespaceComments: true
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: true
@@ -120,4 +116,5 @@ SortIncludes: true
 ReflowComments: false
 
 #IncludeBlocks: Preserve
+#IndentPPDirectives: AfterHash
 ---

--- a/clients/rider/misc.h
+++ b/clients/rider/misc.h
@@ -36,8 +36,7 @@ inline hipError_t
     {
     case hipSuccess: /**< No error */
         break;
-    default:
-    {
+    default: {
         std::stringstream tmp;
         tmp << "HIP_V_THROWERROR< ";
         // tmp << prettyPrintclFFTStatus( res );
@@ -66,8 +65,7 @@ inline rocfft_status lib_V_Throw(rocfft_status      res,
     {
     case rocfft_status_success: /**< No error */
         break;
-    default:
-    {
+    default: {
         std::stringstream tmp;
         tmp << "LIB_V_THROWERROR< ";
         // tmp << prettyPrintclFFTStatus( res );

--- a/clients/rider/rider.cpp
+++ b/clients/rider/rider.cpp
@@ -164,8 +164,7 @@ int transform(size_t*                 lengths,
     // Fill the input buffers
     switch(inArrType)
     {
-    case rocfft_array_type_complex_interleaved:
-    {
+    case rocfft_array_type_complex_interleaved: {
         size_of_input_buffers_in_bytes = fftBatchSize * sizeof(std::complex<T>);
 
         setupBuffers(device_id,
@@ -210,8 +209,7 @@ int transform(size_t*                 lengths,
                     "hipMemcpy failed");
     }
     break;
-    case rocfft_array_type_complex_planar:
-    {
+    case rocfft_array_type_complex_planar: {
         size_of_input_buffers_in_bytes = fftBatchSize * sizeof(T);
 
         setupBuffers(device_id,
@@ -263,8 +261,7 @@ int transform(size_t*                 lengths,
                     "hipMemcpy failed");
     }
     break;
-    case rocfft_array_type_hermitian_interleaved:
-    {
+    case rocfft_array_type_hermitian_interleaved: {
         size_of_input_buffers_in_bytes = fftBatchSize * sizeof(std::complex<T>);
 
         setupBuffers(device_id,
@@ -297,8 +294,7 @@ int transform(size_t*                 lengths,
                     "hipMemcpy failed");
     }
     break;
-    case rocfft_array_type_hermitian_planar:
-    {
+    case rocfft_array_type_hermitian_planar: {
         size_of_input_buffers_in_bytes = fftBatchSize * sizeof(T);
 
         setupBuffers(device_id,
@@ -338,8 +334,7 @@ int transform(size_t*                 lengths,
                     "hipMemcpy failed");
     }
     break;
-    case rocfft_array_type_real:
-    {
+    case rocfft_array_type_real: {
         size_of_input_buffers_in_bytes = fftBatchSize * sizeof(T);
 
         setupBuffers(device_id,
@@ -384,8 +379,7 @@ int transform(size_t*                 lengths,
                     "hipMemcpy failed");
     }
     break;
-    default:
-    {
+    default: {
         throw std::runtime_error("Input layout format not yet supported");
     }
     break;
@@ -484,8 +478,7 @@ int transform(size_t*                 lengths,
     {
         switch(inArrType)
         {
-        case rocfft_array_type_complex_interleaved:
-        {
+        case rocfft_array_type_complex_interleaved: {
             if((outArrType == rocfft_array_type_complex_planar)
                || (outArrType == rocfft_array_type_hermitian_planar))
             {
@@ -494,8 +487,7 @@ int transform(size_t*                 lengths,
             }
             break;
         }
-        case rocfft_array_type_complex_planar:
-        {
+        case rocfft_array_type_complex_planar: {
             if((outArrType == rocfft_array_type_complex_interleaved)
                || (outArrType == rocfft_array_type_hermitian_interleaved))
             {
@@ -504,8 +496,7 @@ int transform(size_t*                 lengths,
             }
             break;
         }
-        case rocfft_array_type_hermitian_interleaved:
-        {
+        case rocfft_array_type_hermitian_interleaved: {
             if(outArrType != rocfft_array_type_real)
             {
                 throw std::runtime_error("Cannot use the same buffer for "
@@ -513,14 +504,12 @@ int transform(size_t*                 lengths,
             }
             break;
         }
-        case rocfft_array_type_hermitian_planar:
-        {
+        case rocfft_array_type_hermitian_planar: {
             throw std::runtime_error("Cannot use the same buffer for "
                                      "planar->interleaved in-place transforms");
             break;
         }
-        case rocfft_array_type_real:
-        {
+        case rocfft_array_type_real: {
             if((outArrType == rocfft_array_type_complex_planar)
                || (outArrType == rocfft_array_type_hermitian_planar))
             {
@@ -659,8 +648,7 @@ int transform(size_t*                 lengths,
         switch(outArrType)
         {
         case rocfft_array_type_hermitian_interleaved:
-        case rocfft_array_type_complex_interleaved:
-        {
+        case rocfft_array_type_complex_interleaved: {
             std::vector<std::complex<T>> output(outfftBatchSize);
 
             if(place == rocfft_placement_inplace)
@@ -709,8 +697,7 @@ int transform(size_t*                 lengths,
         }
         break;
         case rocfft_array_type_hermitian_planar:
-        case rocfft_array_type_complex_planar:
-        {
+        case rocfft_array_type_complex_planar: {
             std::valarray<T> real(outfftBatchSize);
             std::valarray<T> imag(outfftBatchSize);
 
@@ -769,8 +756,7 @@ int transform(size_t*                 lengths,
             }
         }
         break;
-        case rocfft_array_type_real:
-        {
+        case rocfft_array_type_real: {
             std::valarray<T> real(outfftBatchSize);
 
             if(place == rocfft_placement_inplace)
@@ -816,8 +802,7 @@ int transform(size_t*                 lengths,
             }
         }
         break;
-        default:
-        {
+        default: {
             throw std::runtime_error("Input layout format not yet supported");
         }
         break;

--- a/clients/tests/rocfft_transform.h
+++ b/clients/tests/rocfft_transform.h
@@ -594,8 +594,7 @@ private:
         {
             switch(_input_layout)
             {
-            case rocfft_array_type_complex_interleaved:
-            {
+            case rocfft_array_type_complex_interleaved: {
                 if((_output_layout == rocfft_array_type_complex_planar)
                    || (_output_layout == rocfft_array_type_hermitian_planar))
                 {
@@ -604,8 +603,7 @@ private:
                 }
                 break;
             }
-            case rocfft_array_type_complex_planar:
-            {
+            case rocfft_array_type_complex_planar: {
                 if((_output_layout == rocfft_array_type_complex_interleaved)
                    || (_output_layout == rocfft_array_type_hermitian_interleaved))
                 {
@@ -614,8 +612,7 @@ private:
                 }
                 break;
             }
-            case rocfft_array_type_hermitian_interleaved:
-            {
+            case rocfft_array_type_hermitian_interleaved: {
                 if(_output_layout != rocfft_array_type_real)
                 {
                     throw std::runtime_error("Cannot use the same buffer for "
@@ -623,14 +620,12 @@ private:
                 }
                 break;
             }
-            case rocfft_array_type_hermitian_planar:
-            {
+            case rocfft_array_type_hermitian_planar: {
                 throw std::runtime_error("Cannot use the same buffer for "
                                          "planar->interleaved in-place transforms");
                 break;
             }
-            case rocfft_array_type_real:
-            {
+            case rocfft_array_type_real: {
                 if((_output_layout == rocfft_array_type_complex_planar)
                    || (_output_layout == rocfft_array_type_hermitian_planar))
                 {

--- a/clients/tests/test_constants.h
+++ b/clients/tests/test_constants.h
@@ -40,8 +40,8 @@ enum data_pattern
 #define PRE_MULVAL                                             \
     float2 mulval_pre(void* in, uint offset, void* userdata)\n \
     {                                                          \
-        \n float scalar = *((float*)userdata + offset);        \
-        \n float2 ret   = *((float2*)in + offset) * scalar;    \
+        \n float  scalar = *((float*)userdata + offset);       \
+        \n float2 ret    = *((float2*)in + offset) * scalar;   \
         \n return ret;                                         \
         \n                                                     \
     }
@@ -56,7 +56,7 @@ enum data_pattern
     {                                                             \
         \n USER_DATA* data   = ((USER_DATA*)userdata + offset);   \
         \n float      scalar = data->scalar1 * data->scalar2;     \
-        \n float2 ret        = *((float2*)in + offset) * scalar;  \
+        \n float2     ret    = *((float2*)in + offset) * scalar;  \
         \n return ret;                                            \
         \n                                                        \
     }
@@ -64,8 +64,8 @@ enum data_pattern
 #define PRE_MULVAL_DP                                           \
     double2 mulval_pre(void* in, uint offset, void* userdata)\n \
     {                                                           \
-        \n double scalar = *((double*)userdata + offset);       \
-        \n double2 ret   = *((double2*)in + offset) * scalar;   \
+        \n double  scalar = *((double*)userdata + offset);      \
+        \n double2 ret    = *((double2*)in + offset) * scalar;  \
         \n return ret;                                          \
         \n                                                      \
     }
@@ -73,7 +73,7 @@ enum data_pattern
 #define PRE_MULVAL_PLANAR                                                    \
     float2 mulval_pre(void* inRe, void* inIm, uint offset, void* userdata)\n \
     {                                                                        \
-        \n float scalar = *((float*)userdata + offset);                      \
+        \n float  scalar = *((float*)userdata + offset);                     \
         \n float2 ret;                                                       \
         \n        ret.x = *((float*)inRe + offset) * scalar;                 \
         \n        ret.y = *((float*)inIm + offset) * scalar;                 \
@@ -84,7 +84,7 @@ enum data_pattern
 #define PRE_MULVAL_PLANAR_DP                                                  \
     double2 mulval_pre(void* inRe, void* inIm, uint offset, void* userdata)\n \
     {                                                                         \
-        \n double scalar = *((double*)userdata + offset);                     \
+        \n double  scalar = *((double*)userdata + offset);                    \
         \n double2 ret;                                                       \
         \n         ret.x = *((double*)inRe + offset) * scalar;                \
         \n         ret.y = *((double*)inIm + offset) * scalar;                \
@@ -121,7 +121,7 @@ enum data_pattern
         \n float          prev = offset <= 0 ? 0 : *(lds - 1);                         \
         \n float          next = offset >= get_global_size(0) ? 0 : *(lds + 1);        \
         \n float          avg  = (prev + *lds + next) / 3.0f;                          \
-        \n float2 ret          = *((float2*)in + offset) * avg;                        \
+        \n float2         ret  = *((float2*)in + offset) * avg;                        \
         \n return ret;                                                                 \
         \n                                                                             \
     }

--- a/library/include/hipfft.h
+++ b/library/include/hipfft.h
@@ -109,10 +109,10 @@ DLL_PUBLIC hipfftResult hipfftMakePlan1d(hipfftHandle plan,
                                          size_t*      workSize);
 
 DLL_PUBLIC hipfftResult
-           hipfftMakePlan2d(hipfftHandle plan, int nx, int ny, hipfftType type, size_t* workSize);
+    hipfftMakePlan2d(hipfftHandle plan, int nx, int ny, hipfftType type, size_t* workSize);
 
 DLL_PUBLIC hipfftResult
-           hipfftMakePlan3d(hipfftHandle plan, int nx, int ny, int nz, hipfftType type, size_t* workSize);
+    hipfftMakePlan3d(hipfftHandle plan, int nx, int ny, int nz, hipfftType type, size_t* workSize);
 
 DLL_PUBLIC hipfftResult hipfftMakePlanMany(hipfftHandle plan,
                                            int          rank,
@@ -183,10 +183,10 @@ DLL_PUBLIC hipfftResult hipfftGetSize1d(hipfftHandle plan,
                                         size_t*      workSize);
 
 DLL_PUBLIC hipfftResult
-           hipfftGetSize2d(hipfftHandle plan, int nx, int ny, hipfftType type, size_t* workSize);
+    hipfftGetSize2d(hipfftHandle plan, int nx, int ny, hipfftType type, size_t* workSize);
 
 DLL_PUBLIC hipfftResult
-           hipfftGetSize3d(hipfftHandle plan, int nx, int ny, int nz, hipfftType type, size_t* workSize);
+    hipfftGetSize3d(hipfftHandle plan, int nx, int ny, int nz, hipfftType type, size_t* workSize);
 
 DLL_PUBLIC hipfftResult hipfftGetSizeMany(hipfftHandle plan,
                                           int          rank,

--- a/library/include/rocfft.h
+++ b/library/include/rocfft.h
@@ -247,17 +247,17 @@ ROCFFT_EXPORT rocfft_status rocfft_plan_description_set_scale_double( rocfft_pla
  * output buffer
  *  */
 ROCFFT_EXPORT rocfft_status
-              rocfft_plan_description_set_data_layout(rocfft_plan_description description,
-                                                      rocfft_array_type       in_array_type,
-                                                      rocfft_array_type       out_array_type,
-                                                      const size_t*           in_offsets,
-                                                      const size_t*           out_offsets,
-                                                      size_t                  in_strides_size,
-                                                      const size_t*           in_strides,
-                                                      size_t                  in_distance,
-                                                      size_t                  out_strides_size,
-                                                      const size_t*           out_strides,
-                                                      size_t                  out_distance);
+    rocfft_plan_description_set_data_layout(rocfft_plan_description description,
+                                            rocfft_array_type       in_array_type,
+                                            rocfft_array_type       out_array_type,
+                                            const size_t*           in_offsets,
+                                            const size_t*           out_offsets,
+                                            size_t                  in_strides_size,
+                                            const size_t*           in_strides,
+                                            size_t                  in_distance,
+                                            size_t                  out_strides_size,
+                                            const size_t*           out_strides,
+                                            size_t                  out_distance);
 
 /*! @brief Get library version string
  *

--- a/library/src/device/generator/generator.butterfly.hpp
+++ b/library/src/device/generator/generator.butterfly.hpp
@@ -118,8 +118,7 @@ namespace StockhamGenerator
             // Butterfly for different radices
             switch(radix)
             {
-            case 2:
-            {
+            case 2: {
                 if(cReg)
                 {
                     bflyStr += "(*R1) = (*R0) - (*R1);\n\t"
@@ -134,8 +133,7 @@ namespace StockhamGenerator
                 }
             }
             break;
-            case 3:
-            {
+            case 3: {
                 if(fwd)
                 {
                     if(cReg)
@@ -200,8 +198,7 @@ namespace StockhamGenerator
                 }
             }
             break;
-            case 4:
-            {
+            case 4: {
                 if(fwd)
                 {
                     if(cReg)
@@ -262,8 +259,7 @@ namespace StockhamGenerator
                 }
             }
             break;
-            case 5:
-            {
+            case 5: {
                 if(fwd)
                 {
                     if(cReg)
@@ -388,8 +384,7 @@ namespace StockhamGenerator
                 }
             }
             break;
-            case 6:
-            {
+            case 6: {
                 if(fwd)
                 {
                     if(cReg)
@@ -606,8 +601,7 @@ namespace StockhamGenerator
                 }
             }
             break;
-            case 7:
-            {
+            case 7: {
                 static const char* C7SFR = "\
 					/*FFT7 Forward Real */ \n\
 					\n\
@@ -956,8 +950,7 @@ namespace StockhamGenerator
             }
             break;
 
-            case 8:
-            {
+            case 8: {
                 if(fwd)
                 {
                     if(cReg)
@@ -1136,8 +1129,7 @@ namespace StockhamGenerator
                 }
             }
             break;
-            case 10:
-            {
+            case 10: {
                 if(fwd)
                 {
                     if(cReg)
@@ -1506,8 +1498,7 @@ namespace StockhamGenerator
                 }
             }
             break;
-            case 11:
-            {
+            case 11: {
                 static const char* radix11str = " \
 						fptype p0, p1, p2, p3, p4, p5, p6, p7, p8, p9; \n\
 						p0 = ((*R1).x - (*R10).x)*dir; \n\
@@ -1674,8 +1665,7 @@ namespace StockhamGenerator
                 bflyStr += radix11str;
             }
             break;
-            case 13:
-            {
+            case 13: {
 
                 static const char* radix13str = " \
 						fptype p0, p1, p2, p3, p4, p5, p6, p7, p8, p9;\n\

--- a/library/src/include/logging.h
+++ b/library/src/include/logging.h
@@ -79,7 +79,7 @@ protected:
     // Character output
     static void print_value(std::ostream& os, char c)
     {
-        char s[] {c, 0};
+        char s[]{c, 0};
         os << std::quoted(s, '\'');
     }
 
@@ -102,13 +102,13 @@ protected:
     /************************************************************************************
      * Print tuples
      ************************************************************************************/
-    template <typename TUP, size_t idx = std::tuple_size<TUP> {}>
+    template <typename TUP, size_t idx = std::tuple_size<TUP>{}>
     struct print_tuple_recurse
     {
         template <typename F>
         __attribute__((always_inline)) void operator()(F& print_argument, const TUP& tuple)
         {
-            print_tuple_recurse<TUP, idx - 2> {}(print_argument, tuple);
+            print_tuple_recurse<TUP, idx - 2>{}(print_argument, tuple);
             print_argument(std::get<idx - 2>(tuple), std::get<idx - 1>(tuple));
         }
     };
@@ -126,7 +126,7 @@ protected:
     template <typename TUP>
     static void print_tuple(std::ostream& os, const TUP& tuple)
     {
-        static_assert(std::tuple_size<TUP> {} % 2 == 0, "Tuple size must be even");
+        static_assert(std::tuple_size<TUP>{} % 2 == 0, "Tuple size must be even");
 
         // delim starts as "- {" and becomes "," afterwards
         auto print_argument = [&, delim = "- {"](auto&& name, auto&& value) mutable {
@@ -134,7 +134,7 @@ protected:
             print_value(os, value);
             delim = ",";
         };
-        print_tuple_recurse<TUP> {}(print_argument, tuple);
+        print_tuple_recurse<TUP>{}(print_argument, tuple);
         os << " }" << std::endl;
     }
 
@@ -143,16 +143,16 @@ protected:
      ************************************************************************************/
     // Workaround for compilers which don't implement C++14 enum hash (LWG 2148)
     template <typename T>
-    static typename std::enable_if<std::is_enum<T> {}, size_t>::type hash(const T& x)
+    static typename std::enable_if<std::is_enum<T>{}, size_t>::type hash(const T& x)
     {
-        return std::hash<typename std::underlying_type<T>::type> {}(x);
+        return std::hash<typename std::underlying_type<T>::type>{}(x);
     }
 
     // Default hash for non-enum types
     template <typename T>
-    static typename std::enable_if<!std::is_enum<T> {}, size_t>::type hash(const T& x)
+    static typename std::enable_if<!std::is_enum<T>{}, size_t>::type hash(const T& x)
     {
-        return std::hash<T> {}(x);
+        return std::hash<T>{}(x);
     }
 
     // C-style string hash since std::hash does not hash them
@@ -171,12 +171,12 @@ protected:
     }
 
     // Combine tuple value hashes, computing hash of all tuple values
-    template <typename TUP, size_t idx = std::tuple_size<TUP> {}>
+    template <typename TUP, size_t idx = std::tuple_size<TUP>{}>
     struct tuple_hash_recurse
     {
         __attribute__((always_inline)) size_t operator()(const TUP& tup)
         {
-            size_t seed = tuple_hash_recurse<TUP, idx - 2> {}(tup);
+            size_t seed = tuple_hash_recurse<TUP, idx - 2>{}(tup);
             return seed ^ (hash(std::get<idx - 1>(tup)) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
         }
     };
@@ -195,10 +195,10 @@ protected:
     template <typename TUP>
     struct hash_t
     {
-        static_assert(std::tuple_size<TUP> {} % 2 == 0, "Tuple size must be even");
+        static_assert(std::tuple_size<TUP>{} % 2 == 0, "Tuple size must be even");
         size_t operator()(const TUP& x) const
         {
-            return tuple_hash_recurse<TUP> {}(x);
+            return tuple_hash_recurse<TUP>{}(x);
         }
     };
 
@@ -225,13 +225,13 @@ protected:
     }
 
     // Recursively compare tuple values, short-circuiting
-    template <typename TUP, size_t idx = std::tuple_size<TUP> {}>
+    template <typename TUP, size_t idx = std::tuple_size<TUP>{}>
     struct tuple_equal_recurse
     {
         bool operator()(const TUP& t1, const TUP& t2)
         {
             return equal(std::get<idx - 1>(t1), std::get<idx - 1>(t2))
-                   && tuple_equal_recurse<TUP, idx - 2> {}(t1, t2);
+                   && tuple_equal_recurse<TUP, idx - 2>{}(t1, t2);
         }
     };
 
@@ -249,10 +249,10 @@ protected:
     template <typename TUP>
     struct equal_t
     {
-        static_assert(std::tuple_size<TUP> {} % 2 == 0, "Tuple size must be even");
+        static_assert(std::tuple_size<TUP>{} % 2 == 0, "Tuple size must be even");
         __attribute__((flatten)) bool operator()(const TUP& x, const TUP& y) const
         {
-            return tuple_equal_recurse<TUP> {}(x, y);
+            return tuple_equal_recurse<TUP>{}(x, y);
         }
     };
 };
@@ -304,7 +304,7 @@ public:
         // If new entry inserted, replace nullptr with new value
         // If tuple already exists, atomically increment count
         if(inserted)
-            p->second = new std::atomic_size_t {1};
+            p->second = new std::atomic_size_t{1};
         else
             ++*p->second;
     }

--- a/library/src/include/ref_cpu.h
+++ b/library/src/include/ref_cpu.h
@@ -403,8 +403,7 @@ class RefLibOp
 
         switch(data->node->scheme)
         {
-        case CS_KERNEL_STOCKHAM:
-        {
+        case CS_KERNEL_STOCKHAM: {
             RefLibHandle&             refHandle = RefLibHandle::GetRefLibHandle();
             ftype_fftwf_plan_many_dft local_fftwf_plan_many_dft
                 = (ftype_fftwf_plan_many_dft)dlsym(refHandle.fftw3f_lib, "fftwf_plan_many_dft");
@@ -438,8 +437,7 @@ class RefLibOp
             local_fftwf_destroy_plan(p);
         }
         break;
-        case CS_KERNEL_TRANSPOSE:
-        {
+        case CS_KERNEL_TRANSPOSE: {
             CopyInputVector(data_p);
 
             size_t howmany = data->node->batch;
@@ -503,8 +501,7 @@ class RefLibOp
             }
         }
         break;
-        case CS_KERNEL_COPY_R_TO_CMPLX:
-        {
+        case CS_KERNEL_COPY_R_TO_CMPLX: {
             size_t in_size_bytes = (data->node->iDist * data->node->batch) * sizeof(float);
 
             std::vector<float, fftwAllocator<float>> tmp_mem(data->node->iDist * data->node->batch);
@@ -525,8 +522,7 @@ class RefLibOp
             }
         }
         break;
-        case CS_KERNEL_COPY_CMPLX_TO_HERM:
-        {
+        case CS_KERNEL_COPY_CMPLX_TO_HERM: {
             // assump the input is complex, the output is hermitian on take the first
             // [N/2 + 1] elements
             size_t in_size_bytes = (data->node->iDist * data->node->batch) * 2 * sizeof(float);
@@ -555,8 +551,7 @@ class RefLibOp
             }
         }
         break;
-        case CS_KERNEL_COPY_HERM_TO_CMPLX:
-        {
+        case CS_KERNEL_COPY_HERM_TO_CMPLX: {
             // assump the input is hermitian, the output is complex on take the first
             // [N/2 + 1] elements
             size_t in_size_bytes = (data->node->iDist * data->node->batch) * 2 * sizeof(float);
@@ -593,15 +588,13 @@ class RefLibOp
                 }
             }
         }
-        case CS_KERNEL_CHIRP:
-        {
+        case CS_KERNEL_CHIRP: {
             size_t N = data->node->length[0];
             size_t M = data->node->lengthBlue;
             chirp(N, M, data->node->direction, (local_fftwf_complex*)ot.data());
         }
         break;
-        case CS_KERNEL_PAD_MUL:
-        {
+        case CS_KERNEL_PAD_MUL: {
             CopyInputVector(data_p);
 
             size_t howmany = data->node->batch;
@@ -638,8 +631,7 @@ class RefLibOp
             }
         }
         break;
-        case CS_KERNEL_FFT_MUL:
-        {
+        case CS_KERNEL_FFT_MUL: {
             size_t M = data->node->lengthBlue;
             size_t N = data->node->parent->length[0];
 
@@ -667,8 +659,7 @@ class RefLibOp
             }
         }
         break;
-        case CS_KERNEL_RES_MUL:
-        {
+        case CS_KERNEL_RES_MUL: {
             size_t M = data->node->lengthBlue;
             size_t N = data->node->length[0];
 

--- a/library/src/plan.cpp
+++ b/library/src/plan.cpp
@@ -1124,8 +1124,7 @@ void TreeNode::RecursiveBuildTree()
         Build1D();
         break;
 
-    case 2:
-    {
+    case 2: {
         if(scheme == CS_KERNEL_TRANSPOSE)
             return;
 
@@ -1144,8 +1143,7 @@ void TreeNode::RecursiveBuildTree()
 
         switch(scheme)
         {
-        case CS_2D_RTRT:
-        {
+        case CS_2D_RTRT: {
             // first row fft
             TreeNode* row1Plan = TreeNode::CreateNode(this);
 
@@ -1209,8 +1207,7 @@ void TreeNode::RecursiveBuildTree()
             childNodes.push_back(trans2Plan);
         }
         break;
-        case CS_2D_RC:
-        {
+        case CS_2D_RC: {
             // row fft
             TreeNode* rowPlan = TreeNode::CreateNode(this);
 
@@ -1242,8 +1239,7 @@ void TreeNode::RecursiveBuildTree()
             childNodes.push_back(colPlan);
         }
         break;
-        case CS_KERNEL_2D_SINGLE:
-        {
+        case CS_KERNEL_2D_SINGLE: {
         }
         break;
 
@@ -1253,8 +1249,7 @@ void TreeNode::RecursiveBuildTree()
     }
     break;
 
-    case 3:
-    {
+    case 3: {
         if(MultiDimFuseKernelsAvailable)
         {
             // conditions to choose which scheme
@@ -1270,8 +1265,7 @@ void TreeNode::RecursiveBuildTree()
 
         switch(scheme)
         {
-        case CS_3D_RTRT:
-        {
+        case CS_3D_RTRT: {
             // 2d fft
             TreeNode* xyPlan = TreeNode::CreateNode(this);
 
@@ -1339,8 +1333,7 @@ void TreeNode::RecursiveBuildTree()
             childNodes.push_back(trans2Plan);
         }
         break;
-        case CS_3D_RC:
-        {
+        case CS_3D_RC: {
             // 2d fft
             TreeNode* xyPlan = TreeNode::CreateNode(this);
 
@@ -1374,8 +1367,7 @@ void TreeNode::RecursiveBuildTree()
             childNodes.push_back(zPlan);
         }
         break;
-        case CS_KERNEL_3D_SINGLE:
-        {
+        case CS_KERNEL_3D_SINGLE: {
         }
         break;
 
@@ -1844,8 +1836,7 @@ void TreeNode::TraverseTreeAssignParamsLogicA()
 {
     switch(scheme)
     {
-    case CS_REAL_TRANSFORM_USING_CMPLX:
-    {
+    case CS_REAL_TRANSFORM_USING_CMPLX: {
         TreeNode* copyHeadPlan = childNodes[0];
         TreeNode* fftPlan      = childNodes[1];
         TreeNode* copyTailPlan = childNodes[2];
@@ -1875,8 +1866,7 @@ void TreeNode::TraverseTreeAssignParamsLogicA()
         copyTailPlan->oDist     = oDist;
     }
     break;
-    case CS_BLUESTEIN:
-    {
+    case CS_BLUESTEIN: {
         TreeNode* chirpPlan  = childNodes[0];
         TreeNode* padmulPlan = childNodes[1];
         TreeNode* fftiPlan   = childNodes[2];
@@ -1933,8 +1923,7 @@ void TreeNode::TraverseTreeAssignParamsLogicA()
         resmulPlan->oDist     = oDist;
     }
     break;
-    case CS_L1D_TRTRT:
-    {
+    case CS_L1D_TRTRT: {
         size_t biggerDim = childNodes[0]->length[0] > childNodes[0]->length[1]
                                ? childNodes[0]->length[0]
                                : childNodes[0]->length[1];
@@ -2132,8 +2121,7 @@ void TreeNode::TraverseTreeAssignParamsLogicA()
             trans3Plan->outStride.push_back(outStride[index]);
     }
     break;
-    case CS_L1D_CC:
-    {
+    case CS_L1D_CC: {
         TreeNode* col2colPlan = childNodes[0];
         TreeNode* row2colPlan = childNodes[1];
 
@@ -2254,8 +2242,7 @@ void TreeNode::TraverseTreeAssignParamsLogicA()
         }
     }
     break;
-    case CS_L1D_CRT:
-    {
+    case CS_L1D_CRT: {
         TreeNode* col2colPlan = childNodes[0];
         TreeNode* row2rowPlan = childNodes[1];
         TreeNode* transPlan   = childNodes[2];
@@ -2393,8 +2380,7 @@ void TreeNode::TraverseTreeAssignParamsLogicA()
         }
     }
     break;
-    case CS_2D_RTRT:
-    {
+    case CS_2D_RTRT: {
         TreeNode* row1Plan   = childNodes[0];
         TreeNode* trans1Plan = childNodes[1];
         TreeNode* row2Plan   = childNodes[2];
@@ -2453,8 +2439,7 @@ void TreeNode::TraverseTreeAssignParamsLogicA()
     }
     break;
     case CS_2D_RC:
-    case CS_2D_STRAIGHT:
-    {
+    case CS_2D_STRAIGHT: {
         TreeNode* rowPlan = childNodes[0];
         TreeNode* colPlan = childNodes[1];
 
@@ -2483,8 +2468,7 @@ void TreeNode::TraverseTreeAssignParamsLogicA()
         colPlan->oDist     = colPlan->iDist;
     };
     break;
-    case CS_3D_RTRT:
-    {
+    case CS_3D_RTRT: {
         TreeNode* xyPlan     = childNodes[0];
         TreeNode* trans1Plan = childNodes[1];
         TreeNode* zPlan      = childNodes[2];
@@ -2546,8 +2530,7 @@ void TreeNode::TraverseTreeAssignParamsLogicA()
     }
     break;
     case CS_3D_RC:
-    case CS_3D_STRAIGHT:
-    {
+    case CS_3D_STRAIGHT: {
         TreeNode* xyPlan = childNodes[0];
         TreeNode* zPlan  = childNodes[1];
 

--- a/library/src/powX.cpp
+++ b/library/src/powX.cpp
@@ -92,8 +92,7 @@ void PlanPowX(ExecPlan& execPlan)
 
         switch(execPlan.execSeq[i]->scheme)
         {
-        case CS_KERNEL_STOCKHAM:
-        {
+        case CS_KERNEL_STOCKHAM: {
             // get working group size and number of transforms
             size_t workGroupSize;
             size_t numTransforms;

--- a/utils/simple_bench/kernels/pow2_large_entry.h
+++ b/utils/simple_bench/kernels/pow2_large_entry.h
@@ -42,7 +42,7 @@ __global__ void transpose_var1(T*          twiddles_large,
     // wgUnroll ][ wgTileExtent.x ];
 
     constexpr size_t TWIDTH = 64 / (sizeof(T) / 8);
-    __shared__ T lds[TWIDTH][TWIDTH];
+    __shared__ T     lds[TWIDTH][TWIDTH];
 
     size_t currDimIndex;
     size_t rowSizeinUnits;


### PR DESCRIPTION
- Additional options are now available in clang-format, and they need to be applied to Jenkins after I upgraded CI from rocm2.4 to rocm2.5
