### PR TITLE
[rocfft] Include <iostream> as `std::cerr` is referenced.

### DIFF
--- a/library/src/auxiliary.cpp
+++ b/library/src/auxiliary.cpp
@@ -24,6 +24,7 @@
 #include "helper_math.h"
 #endif
 
+#include <iostream>
 #include "logging.h"
 #include "rocfft.h"
 #include "rocfft_hip.h"


### PR DESCRIPTION
resolve TC build

the issue is caused by missing header, 'std::cerr' is referenced but <iostream> is not included