### PR TITLE
Revert "[rocfft] Include <iostream> as `std::cerr` is referenced."

### DIFF
--- a/library/src/auxiliary.cpp
+++ b/library/src/auxiliary.cpp
@@ -24,7 +24,6 @@
 #include "helper_math.h"
 #endif
 
-#include <iostream>
 #include "logging.h"
 #include "rocfft.h"
 #include "rocfft_hip.h"


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/rocFFT#203

Please re-submit with either Fei or myself as a reviewer.