### PR TITLE
[rocfft] Include <iostream> as `std::cerr` is referenced.

### DIFF
--- a/library/src/auxiliary.cpp
+++ b/library/src/auxiliary.cpp
@@ -27,6 +27,7 @@
 #include "logging.h"
 #include "rocfft.h"
 #include "rocfft_hip.h"
+#include <iostream>
 
 /*******************************************************************************
  * Static handle data


### PR DESCRIPTION
It is required to fix TC build as reported in http://ontrack-internal.amd.com/browse/SWDEV-193409