### PR TITLE
Removing older rocfft package from centos container

### DIFF
--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -6,6 +6,9 @@ LABEL maintainer="akila.premachandra@amd.com"
 
 ARG user_uid
 
+# The centOS container has an older version of the rocFFT package installed
+RUN yum remove rocfft
+
 RUN yum install -y \
     sudo \
     rock-dkms \

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -7,7 +7,7 @@ LABEL maintainer="akila.premachandra@amd.com"
 ARG user_uid
 
 # The centOS container has an older version of the rocFFT package installed
-RUN yum remove rocfft
+RUN yum remove -y rocfft
 
 RUN yum install -y \
     sudo \


### PR DESCRIPTION
- Ran on container with dev-centos-7:2.5 docker image. Can confirm that there is an older rocFFT package installed on the base image. Removing it on the build file should fix the problem. 
- Permissions issue with remove, will be fixed in next commit