### PR TITLE
Remove FFTW dependency for hipfft examples and simplify examples.

### DIFF
--- a/clients/samples/hipfft/CMakeLists.txt
+++ b/clients/samples/hipfft/CMakeLists.txt
@@ -6,33 +6,18 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 find_package(hip)
 find_package(rocfft)
-find_package(FFTW3f)
 
-# ########################################################################
-# The following check are hacks to get compiles working for CUDA backend
-# These should be removed in the future.
-
-# NVCC can not compile fftw.3 header file appropriately before v3.3.5
-# https://github.com/FFTW/fftw3/issues/18
-# v3.3.5 is installed by default on Ubuntu 16, workaround is to trick fftw3
-# into thinking nvcc is an Intel compiler as desribed in above issue
-if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-  add_definitions( -D__INTEL_COMPILER )
-endif( )
-# ########################################################################
-
-set( sample_list hipfft_planmany_2d_r2c hipfft_planmany_2d_z2z hipfft_setworkarea)
+set( sample_list hipfft_planmany_2d_z2z hipfft_planmany_2d_r2c hipfft_setworkarea)
 
 foreach( sample ${sample_list} )
 
   add_executable( ${sample} ${sample}.cpp )
 
   target_include_directories( ${sample}
-    PRIVATE $<BUILD_INTERFACE:${FFTW_INCLUDE_DIRS}>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   )
 
-  target_link_libraries( ${sample} PRIVATE roc::rocfft fftw3 fftw3f )
+  target_link_libraries( ${sample} PRIVATE roc::rocfft)
 
   target_compile_features( ${sample} PRIVATE cxx_static_assert cxx_nullptr cxx_auto_type )
 

--- a/clients/samples/hipfft/hipfft_planmany_2d_r2c.cpp
+++ b/clients/samples/hipfft/hipfft_planmany_2d_r2c.cpp
@@ -6,6 +6,8 @@
 
 int main()
 {
+    std::cout << "2D double-precision real-to-complex transform using advanced interface\n";
+    
     int rank    = 2;
     int n[2]    = {4, 5};
     int howmany = 3; // batch size

--- a/clients/samples/hipfft/hipfft_planmany_2d_r2c.cpp
+++ b/clients/samples/hipfft/hipfft_planmany_2d_r2c.cpp
@@ -7,7 +7,7 @@
 int main()
 {
     std::cout << "2D double-precision real-to-complex transform using advanced interface\n";
-    
+
     int rank    = 2;
     int n[2]    = {4, 5};
     int howmany = 3; // batch size

--- a/clients/samples/hipfft/hipfft_planmany_2d_r2c.cpp
+++ b/clients/samples/hipfft/hipfft_planmany_2d_r2c.cpp
@@ -1,103 +1,67 @@
-#include <iomanip>
-#include <iostream>
-
-#include <fftw3.h>
+#include <complex>
 #include <hip/hip_runtime.h>
 #include <hipfft.h>
+#include <iostream>
+#include <vector>
 
 int main()
 {
-    ///------------------------------------------------------------------------
-    /// fftwf_plan_many_dft_r2c vs hipfftPlanMany
-    /// 2D R2C forward in-place
+    int rank    = 2;
+    int n[2]    = {4, 5};
+    int howmany = 3; // batch size
 
-    float checksum[3] = {0, 0, 0}; // 0 for input, 1 for fftw cpu result, 2 for hipfft gpu result
-    int   rank        = 2;
-    int   n[2]        = {5, 6};
-    int   howmany     = 3; // batch size
-
-    unsigned flags                       = FFTW_ESTIMATE;
-    int      n1_complex_elements         = n[1] / 2 + 1;
-    int      n1_padding_real_elements    = n1_complex_elements * 2;
-    int      total_padding_real_elements = n[0] * n1_padding_real_elements * howmany;
-    int      total_bytes                 = sizeof(float) * total_padding_real_elements;
+    int n1_complex_elements      = n[1] / 2 + 1;
+    int n1_padding_real_elements = n1_complex_elements * 2;
 
     int istride    = 1;
-    int ostride    = 1;
-    int inembed[2] = {n[0], n1_padding_real_elements};
-    int onembed[2] = {n[0], n1_complex_elements};
-    int idist      = n[0] * n1_padding_real_elements;
-    int odist      = n[0] * n1_complex_elements;
+    int ostride    = istride;
+    int inembed[2] = {istride * n[0], istride * n1_padding_real_elements};
+    int onembed[2] = {ostride * n[0], ostride * n1_complex_elements};
+    int idist      = inembed[0] * inembed[1];
+    int odist      = onembed[0] * onembed[1];
 
-    float*         cpu_in_out = new float[total_padding_real_elements];
-    fftwf_complex* cpu_out    = (fftwf_complex*)fftw_malloc(total_bytes);
+    std::cout << "n: " << n[0] << " " << n[1] << "\n"
+              << "howmany: " << howmany << "\n"
+              << "istride: " << istride << "\tostride: " << ostride << "\n"
+              << "inembed: " << inembed[0] << " " << inembed[1] << "\n"
+              << "onembed: " << onembed[0] << " " << onembed[1] << "\n"
+              << "idist: " << idist << "\todist: " << odist << "\n"
+              << std::endl;
 
-    const fftwf_plan fftwPlan = fftwf_plan_many_dft_r2c(rank,
-                                                        n,
-                                                        howmany,
-                                                        cpu_in_out,
-                                                        inembed,
-                                                        istride,
-                                                        idist,
-                                                        (fftwf_complex*)cpu_in_out,
-                                                        onembed,
-                                                        ostride,
-                                                        odist,
-                                                        flags);
+    std::vector<float> data(howmany * idist);
+    const auto         total_bytes = data.size() * sizeof(decltype(data)::value_type);
 
-    for(int i = 0; i < total_padding_real_elements; i++)
+    std::cout << "input:\n";
+    std::fill(data.begin(), data.end(), 0.0);
+    for(int ibatch = 0; ibatch < howmany; ++ibatch)
     {
-        cpu_in_out[i] = (i + 20) % 11;
-        checksum[0] += cpu_in_out[i];
-    }
-
-    std::cout.setf(std::ios::fixed);
-    std::cout.setf(std::ios::right);
-    std::cout << "fftw inputs:---------------------------------------------\n";
-    for(int i = 0; i < howmany; i++)
-    {
-        std::cout << "----------batch " << i << std::endl;
-        for(int j = 0; j < n[0]; j++)
+        for(int i = 0; i < n[0]; i++)
         {
-            for(int k = 0; k < n1_padding_real_elements; k++)
+            for(int j = 0; j < n[1]; j++)
             {
-                int idx = i * n[0] * n1_padding_real_elements + j * n1_padding_real_elements + k;
-                std::cout << "[" << j << ", " << k << "]: (" << std::setprecision(2) << std::setw(6)
-                          << cpu_in_out[idx] << ") ";
-                checksum[0] += cpu_in_out[idx];
+                const auto pos = ibatch * idist + istride * (i * inembed[1] + j);
+                data[pos]      = i + ibatch + j;
             }
-            std::cout << std::endl;
         }
     }
-
-    fftwf_execute(fftwPlan);
-
-    std::cout << "fftw outputs:--------------------------------------------\n";
-    for(int i = 0; i < howmany; i++)
+    for(int ibatch = 0; ibatch < howmany; ++ibatch)
     {
-        std::cout << "----------batch " << i << std::endl;
-        for(int j = 0; j < n[0]; j++)
+        std::cout << "batch: " << ibatch << "\n";
+        for(int i = 0; i < inembed[0]; i++)
         {
-            for(int k = 0; k < n1_padding_real_elements; k++)
+            for(int j = 0; j < inembed[1]; j++)
             {
-                int idx = i * n[0] * n1_padding_real_elements + j * n1_padding_real_elements + k;
-                std::cout << "[" << j << ", " << k << "]: (" << std::setprecision(2) << std::setw(6)
-                          << cpu_in_out[idx] << ") ";
-                checksum[1] += cpu_in_out[idx];
+                const auto pos = ibatch * idist + i * inembed[1] + j;
+                std::cout << data[pos] << " ";
             }
-            std::cout << std::endl;
+            std::cout << "\n";
         }
+        std::cout << "\n";
     }
-
-    // reinitialize
-    for(int i = 0; i < total_padding_real_elements; i++)
-    {
-        cpu_in_out[i] = (i + 20) % 11;
-    }
+    std::cout << std::endl;
 
     hipfftHandle hipForwardPlan;
     hipfftResult result;
-
     result = hipfftPlanMany(&hipForwardPlan,
                             rank,
                             n,
@@ -110,39 +74,33 @@ int main()
                             HIPFFT_R2C,
                             howmany);
 
-    hipfftReal* gpu_in_out;
-    hipMalloc((void**)&gpu_in_out, total_bytes);
-    hipMemcpy(gpu_in_out, (void*)cpu_in_out, total_bytes, hipMemcpyHostToDevice);
+    hipfftReal* gpu_data;
+    hipMalloc((void**)&gpu_data, total_bytes);
+    hipMemcpy(gpu_data, (void*)data.data(), total_bytes, hipMemcpyHostToDevice);
 
-    result = hipfftExecR2C(hipForwardPlan, gpu_in_out, (hipfftComplex*)gpu_in_out);
+    result = hipfftExecR2C(hipForwardPlan, gpu_data, (hipfftComplex*)gpu_data);
 
-    hipMemcpy((void*)cpu_in_out, gpu_in_out, total_bytes, hipMemcpyDeviceToHost);
+    hipMemcpy((void*)data.data(), gpu_data, total_bytes, hipMemcpyDeviceToHost);
 
-    std::cout << "hipfft outputs:------------------------------------------\n";
-    for(int i = 0; i < howmany; i++)
+    std::cout << "output:\n";
+    const std::complex<float>* output = (std::complex<float>*)data.data();
+    for(int ibatch = 0; ibatch < howmany; ++ibatch)
     {
-        std::cout << "----------batch " << i << std::endl;
-        for(int j = 0; j < n[0]; j++)
+        std::cout << "batch: " << ibatch << "\n";
+        for(int i = 0; i < onembed[0]; i++)
         {
-            for(int k = 0; k < n1_padding_real_elements; k++)
+            for(int j = 0; j < onembed[1]; j++)
             {
-                int idx = i * n[0] * n1_padding_real_elements + j * n1_padding_real_elements + k;
-                std::cout << "[" << j << ", " << k << "]: (" << std::setprecision(2) << std::setw(6)
-                          << cpu_in_out[idx] << ") ";
-                checksum[2] += cpu_in_out[idx];
+                const auto pos = ibatch * odist + i * onembed[1] + j;
+                std::cout << output[pos] << " ";
             }
-            std::cout << std::endl;
+            std::cout << "\n";
         }
+        std::cout << "\n";
     }
-
-    std::cout << "\n----------------------------------------------------\n"
-              << "Final sum, input: " << checksum[0] << ", fftw result: " << checksum[1]
-              << ", hipfft result: " << checksum[2] << std::endl;
+    std::cout << std::endl;
 
     hipfftDestroy(hipForwardPlan);
-    hipFree(gpu_in_out);
-
-    fftwf_destroy_plan(fftwPlan);
-    fftwf_free(cpu_in_out);
+    hipFree(gpu_data);
     return 0;
 }

--- a/clients/samples/hipfft/hipfft_planmany_2d_z2z.cpp
+++ b/clients/samples/hipfft/hipfft_planmany_2d_z2z.cpp
@@ -20,119 +20,102 @@
 * THE SOFTWARE.
 *******************************************************************************/
 
-#include <iomanip>
-#include <iostream>
-
-#include <fftw3.h>
+#include <complex>
 #include <hip/hip_runtime.h>
 #include <hipfft.h>
-
-using namespace std;
+#include <iostream>
 
 int main()
 {
     ///------------------------------------------------------------------------
     /// 2d Z2Z forward hipfftPlanMany explicit params
 
-    int      rank    = 2;
-    int      n[2]    = {5, 6};
-    int      howmany = 3;
-    int      idist   = n[0] * n[1];
-    int      odist   = n[0] * n[1];
-    int      istride = 1;
-    int      ostride = 1; // array is contiguous in memory
-    int *    inembed = n, *onembed = n;
-    int      sign        = FFTW_FORWARD;
-    unsigned flags       = FFTW_PATIENT;
-    size_t   total_bytes = sizeof(fftw_complex) * howmany * n[0] * n[1];
+    int rank    = 2;
+    int n[2]    = {4, 5};
+    int howmany = 3;
 
-    fftw_complex* fftw_in  = (fftw_complex*)fftw_malloc(total_bytes);
-    fftw_complex* fftw_out = (fftw_complex*)fftw_malloc(total_bytes);
+    // array is contiguous in memory
+    int istride = 1;
+    // in-place transforms require istride=ostride
+    int ostride = istride;
 
-    const fftw_plan fftwPlan = fftw_plan_many_dft(rank,
-                                                  n,
-                                                  howmany,
-                                                  fftw_in,
-                                                  inembed,
-                                                  istride,
-                                                  idist,
-                                                  fftw_out,
-                                                  onembed,
-                                                  ostride,
-                                                  odist,
-                                                  sign,
-                                                  flags);
+    // we choose to have no padding around our data:
+    int inembed[2] = {istride * n[0], istride * n[1]};
+    // in-place transforms require inembed=oneembed:
+    int onembed[2] = {inembed[0], inembed[1]};
 
-    for(int i = 0; i < n[0]; i++)
-        for(int j = 0; j < n[1]; j++)
-        {
-            fftw_in[i * n[1] + j][0] = fftw_in[i * n[1] + j][1] = (i * n[1] + j + 1 + 30) % 12;
-            fftw_out[i * n[1] + j][0] = fftw_out[i * n[1] + j][1] = 0;
-        }
+    int idist = inembed[0] * inembed[1];
+    int odist = onembed[0] * onembed[1];
 
-    fftw_execute(fftwPlan);
+    std::cout << "n: " << n[0] << " " << n[1] << "\n"
+              << "howmany: " << howmany << "\n"
+              << "istride: " << istride << "\tostride: " << ostride << "\n"
+              << "inembed: " << inembed[0] << " " << inembed[1] << "\n"
+              << "onembed: " << onembed[0] << " " << onembed[1] << "\n"
+              << "idist: " << idist << "\todist: " << odist << "\n"
+              << std::endl;
 
-    std::cout << "fftw inputs:\n";
-    std::cout.setf(ios::fixed);
-    std::cout.setf(ios::right);
-    std::cout.setf(ios::showpos);
-    for(int i = 0; i < n[0]; i++)
+    std::vector<std::complex<double>> data(howmany * idist);
+    const auto total_bytes = data.size() * sizeof(decltype(data)::value_type);
+
+    std::cout << "input:\n";
+    std::fill(data.begin(), data.end(), 0.0);
+    for(int ibatch = 0; ibatch < howmany; ++ibatch)
     {
-        for(int j = 0; j < n[1]; j++)
+        for(int i = 0; i < n[0]; i++)
         {
-            std::cout << "[" << i << ", " << j << "] : (" << setprecision(2) << setw(6)
-                      << fftw_in[i * n[1] + j][0] << ", " << setprecision(2) << setw(6)
-                      << fftw_in[i * n[1] + j][1] << ")  ";
+            for(int j = 0; j < n[1]; j++)
+            {
+                const auto pos = ibatch * idist + istride * (i * inembed[1] + j);
+                data[pos]      = std::complex<double>(i + ibatch, j);
+            }
         }
-        std::cout << std::endl;
     }
-    std::cout << "fftw outputs:\n";
-    for(int i = 0; i < n[0]; i++)
+    for(int ibatch = 0; ibatch < howmany; ++ibatch)
     {
-        for(int j = 0; j < n[1]; j++)
+        std::cout << "batch: " << ibatch << "\n";
+        for(int i = 0; i < inembed[0]; i++)
         {
-            std::cout << "[" << i << ", " << j << "] : (" << setprecision(2) << setw(6)
-                      << fftw_out[i * n[1] + j][0] << ", " << setprecision(2) << setw(6)
-                      << fftw_out[i * n[1] + j][1] << ")  ";
+            for(int j = 0; j < inembed[1]; j++)
+            {
+                const auto pos = ibatch * idist + i * inembed[1] + j;
+                std::cout << data[pos] << " ";
+            }
+            std::cout << "\n";
         }
-        std::cout << std::endl;
+        std::cout << "\n";
     }
-
-    for(int i = 0; i < n[0]; i++)
-        for(int j = 0; j < n[1]; j++)
-        {
-            fftw_out[i * n[1] + j][0] = fftw_out[i * n[1] + j][1] = 0;
-        }
+    std::cout << std::endl;
 
     hipfftHandle hipPlan;
     hipfftResult result;
-
     result = hipfftPlanMany(
         &hipPlan, rank, n, inembed, istride, idist, onembed, ostride, odist, HIPFFT_Z2Z, howmany);
 
     hipfftDoubleComplex* d_in_out;
     hipMalloc((void**)&d_in_out, total_bytes);
-    hipMemcpy(d_in_out, (void*)fftw_in, total_bytes, hipMemcpyHostToDevice);
+    hipMemcpy(d_in_out, (void*)data.data(), total_bytes, hipMemcpyHostToDevice);
 
     result = hipfftExecZ2Z(hipPlan, d_in_out, d_in_out, HIPFFT_FORWARD);
 
-    hipMemcpy((void*)fftw_out, d_in_out, total_bytes, hipMemcpyDeviceToHost);
+    hipMemcpy((void*)data.data(), d_in_out, total_bytes, hipMemcpyDeviceToHost);
 
-    std::cout << "hipfft outputs:\n";
-    for(int i = 0; i < n[0]; i++)
+    std::cout << "output:\n";
+    for(int ibatch = 0; ibatch < howmany; ++ibatch)
     {
-        for(int j = 0; j < n[1]; j++)
+        std::cout << "batch: " << ibatch << "\n";
+        for(int i = 0; i < onembed[0]; i++)
         {
-            std::cout << "[" << i << ", " << j << "] : (" << setprecision(2) << setw(6)
-                      << fftw_out[i * n[1] + j][0] << ", " << setprecision(2) << setw(6)
-                      << fftw_out[i * n[1] + j][1] << ")  ";
+            for(int j = 0; j < onembed[1]; j++)
+            {
+                const auto pos = ibatch * odist + i * onembed[1] + j;
+                std::cout << data[pos] << " ";
+            }
+            std::cout << "\n";
         }
-        std::cout << std::endl;
+        std::cout << "\n";
     }
-
-    fftw_destroy_plan(fftwPlan);
-    fftw_free(fftw_in);
-    fftw_free(fftw_out);
+    std::cout << std::endl;
 
     hipFree(d_in_out);
 }

--- a/clients/samples/hipfft/hipfft_planmany_2d_z2z.cpp
+++ b/clients/samples/hipfft/hipfft_planmany_2d_z2z.cpp
@@ -28,7 +28,7 @@
 int main()
 {
     std::cout << "2D double-precision complex-to-complex transform using advanced interface\n";
-    
+
     int rank    = 2;
     int n[2]    = {4, 5};
     int howmany = 3;

--- a/clients/samples/hipfft/hipfft_planmany_2d_z2z.cpp
+++ b/clients/samples/hipfft/hipfft_planmany_2d_z2z.cpp
@@ -27,9 +27,8 @@
 
 int main()
 {
-    ///------------------------------------------------------------------------
-    /// 2d Z2Z forward hipfftPlanMany explicit params
-
+    std::cout << "2D double-precision complex-to-complex transform using advanced interface\n";
+    
     int rank    = 2;
     int n[2]    = {4, 5};
     int howmany = 3;

--- a/clients/samples/hipfft/hipfft_setworkarea.cpp
+++ b/clients/samples/hipfft/hipfft_setworkarea.cpp
@@ -20,10 +20,9 @@
 * THE SOFTWARE.
 *******************************************************************************/
 
-#include <iomanip>
+#include <complex>
 #include <iostream>
 
-#include <fftw3.h>
 #include <hip/hip_runtime.h>
 #include <hipfft.h>
 
@@ -35,88 +34,65 @@ int main()
     hipfftGetProperty(MAJOR_VERSION, &major_version);
     std::cout << "hipFFT major_version " << major_version << std::endl;
 
-    const size_t N = 256;
+    const size_t N        = 9;
+    const size_t Ncomplex = (N / 2 + 1);
 
-    /// FFTW reference compute
+    std::vector<float>               rdata(N);
+    std::vector<std::complex<float>> cdata(Ncomplex);
 
-    std::vector<float2> cx(N);
+    size_t real_bytes    = sizeof(decltype(rdata)::value_type) * rdata.size();
+    size_t complex_bytes = sizeof(decltype(cdata)::value_type) * cdata.size();
 
-    size_t complex_input_bytes = sizeof(fftwf_complex) * (N / 2 + 1);
-    size_t real_output_bytes   = sizeof(float) * N;
-
-    fftwf_complex* in  = (fftwf_complex*)fftwf_malloc(complex_input_bytes);
-    float*         out = (float*)fftwf_malloc(real_output_bytes);
-    fftwf_plan     p   = fftwf_plan_dft_c2r_1d(N, in, out, FFTW_ESTIMATE);
-
-    for(size_t i = 0; i < (N / 2 + 1); i++)
+    std::cout << "input:\n";
+    for(size_t i = 0; i < N; i++)
     {
-        cx[i].x = in[i][0] = i + (i % 3) - (i % 7);
-        cx[i].y = in[i][1] = 0;
+        rdata[i] = i;
     }
-
-    fftwf_execute(p);
-
-    /// hipfft gpu compute
+    for(size_t i = 0; i < N; i++)
+    {
+        std::cout << rdata[i] << " ";
+    }
+    std::cout << std::endl;
 
     // Create HIP device object.
-    hipfftComplex* x;
-    hipMalloc(&x, std::max(complex_input_bytes, real_output_bytes));
+    hipfftReal* x;
+    hipMalloc(&x, real_bytes);
+    hipfftComplex* y;
+    hipMalloc(&y, complex_bytes);
 
-    //  Copy input data to device
-    hipMemcpy(x, &cx[0], complex_input_bytes, hipMemcpyHostToDevice);
+    // Copy input data to device
+    hipMemcpy(x, rdata.data(), real_bytes, hipMemcpyHostToDevice);
 
-    // Create plan
+    size_t workSize;
+    hipfftEstimate1d(N, HIPFFT_R2C, 1, &workSize);
+    std::cout << "hipfftEstimate 1d workSize: " << workSize << std::endl;
+
     hipfftHandle plan = NULL;
-    size_t       workSize;
-
-    hipfftEstimate1d(N, HIPFFT_C2R, 1, &workSize);
-    std::cout << "hipfftEstimate1d workSize: " << workSize << std::endl;
-
     hipfftCreate(&plan);
     hipfftSetAutoAllocation(plan, 0);
-
-    hipfftMakePlan1d(plan, N, HIPFFT_C2R, 1, &workSize);
+    hipfftMakePlan1d(plan, N, HIPFFT_R2C, 1, &workSize);
 
     // Set work buffer
     hipfftComplex* workBuf;
     hipMalloc(&workBuf, workSize);
     hipfftSetWorkArea(plan, workBuf);
-
     hipfftGetSize(plan, &workSize);
     std::cout << "hipfftGetSize workSize: " << workSize << std::endl;
 
     // Execute plan
-    hipfftExecC2R(plan, x, (hipfftReal*)x);
+    hipfftExecR2C(plan, x, (hipfftComplex*)y);
 
     // Copy result back to host
-    std::vector<float> y(N);
-    hipMemcpy(&y[0], x, real_output_bytes, hipMemcpyDeviceToHost);
+    hipMemcpy(cdata.data(), y, complex_bytes, hipMemcpyDeviceToHost);
 
-    // Destroy plan
-    hipfftDestroy(plan);
-
-    double error      = 0;
-    size_t element_id = 0;
-    for(size_t i = 0; i < N; i++)
+    std::cout << "output:\n";
+    for(size_t i = 0; i < Ncomplex; i++)
     {
-        if(i < 32)
-            printf("element %d: FFTW result %f; hipFFT result %f \n", (int)i, out[i], y[i]);
-        double err = fabs(out[i] - y[i]);
-        if(err > error)
-        {
-            error      = err;
-            element_id = i;
-        }
+        std::cout << cdata[i] << " ";
     }
+    std::cout << std::endl;
 
-    printf("......\nmax error of FFTW and hipFFT is %e at element %d\n",
-           error / fabs(out[element_id]),
-           (int)element_id);
-
-    fftwf_destroy_plan(p);
-    fftwf_free(in);
-    fftwf_free(out);
-
+    hipfftDestroy(plan);
     hipFree(x);
     hipFree(workBuf);
 


### PR DESCRIPTION
Summary of proposed changes:
-  Removes FFTW dependency for hipfft examples
-  Simplify examples so that they're more pedagogical.
