### PR TITLE
Fix out-of-place 2D Bluestein transforms

### DIFF
--- a/clients/tests/accuracy_test_1D.cpp
+++ b/clients/tests/accuracy_test_1D.cpp
@@ -445,6 +445,14 @@ INSTANTIATE_TEST_CASE_P(rocfft_pow_mix_1D,
                         accuracy_test_real,
                         Combine(ValuesIn(mix_range), ValuesIn(batch_range)));
 
+INSTANTIATE_TEST_CASE_P(rocfft_prime_1D,
+                        accuracy_test_real,
+                        Combine(ValuesIn(prime_range), ValuesIn(batch_range)));
+
+
+
+
+
 // *****************************************************
 // *****************************************************
 // TESTS disabled by default since they take a long time to execute

--- a/clients/tests/accuracy_test_1D.cpp
+++ b/clients/tests/accuracy_test_1D.cpp
@@ -449,10 +449,6 @@ INSTANTIATE_TEST_CASE_P(rocfft_prime_1D,
                         accuracy_test_real,
                         Combine(ValuesIn(prime_range), ValuesIn(batch_range)));
 
-
-
-
-
 // *****************************************************
 // *****************************************************
 // TESTS disabled by default since they take a long time to execute

--- a/clients/tests/accuracy_test_2D.cpp
+++ b/clients/tests/accuracy_test_2D.cpp
@@ -76,19 +76,23 @@ protected:
                                          following size , {78125, 390625},     \
                                          {1953125, 9765625} */
 
+#define PRIME_RANGE  {7, 25}, {11, 625}, {13, 15625}, {1, 11}, {11, 1}, {8191, 243}, {7,11}, \
+        {7,32}, {1009, 1009}, 
+
 static std::vector<std::vector<size_t>> pow2_range = {POW2_RANGE};
 static std::vector<std::vector<size_t>> pow3_range = {POW3_RANGE};
 static std::vector<std::vector<size_t>> pow5_range = {POW5_RANGE};
+static std::vector<std::vector<size_t>> prime_range = {PRIME_RANGE};
 
 static size_t batch_range[] = {1};
 
 static size_t stride_range[] = {1}; // 1: assume packed data
 
 static rocfft_result_placement placeness_range[] = {
-    /*rocfft_placement_notinplace,*/ rocfft_placement_inplace};
+    rocfft_placement_notinplace, rocfft_placement_inplace};
 
 static rocfft_transform_type transform_range[] = {
-    /*rocfft_transform_type_complex_forward, */ rocfft_transform_type_complex_inverse};
+    rocfft_transform_type_complex_forward, rocfft_transform_type_complex_inverse};
 
 static data_pattern pattern_range[] = {sawtooth};
 
@@ -435,6 +439,16 @@ INSTANTIATE_TEST_CASE_P(rocfft_pow5_2D,
                                 ValuesIn(transform_range),
                                 ValuesIn(stride_range),
                                 ValuesIn(pattern_range)));
+
+INSTANTIATE_TEST_CASE_P(rocfft_prime_2D,
+                        accuracy_test_complex_2D,
+                        Combine(ValuesIn(prime_range),
+                                ValuesIn(batch_range),
+                                ValuesIn(placeness_range),
+                                ValuesIn(transform_range),
+                                ValuesIn(stride_range),
+                                ValuesIn(pattern_range)));
+
 
 // *****************************************************
 // REAL  HERMITIAN

--- a/clients/tests/accuracy_test_2D.cpp
+++ b/clients/tests/accuracy_test_2D.cpp
@@ -76,23 +76,23 @@ protected:
                                          following size , {78125, 390625},     \
                                          {1953125, 9765625} */
 
-#define PRIME_RANGE  {7, 25}, {11, 625}, {13, 15625}, {1, 11}, {11, 1}, {8191, 243}, {7,11}, \
-        {7,32}, {1009, 1009}, 
+#define PRIME_RANGE \
+    {7, 25}, {11, 625}, {13, 15625}, {1, 11}, {11, 1}, {8191, 243}, {7, 11}, {7, 32}, {1009, 1009},
 
-static std::vector<std::vector<size_t>> pow2_range = {POW2_RANGE};
-static std::vector<std::vector<size_t>> pow3_range = {POW3_RANGE};
-static std::vector<std::vector<size_t>> pow5_range = {POW5_RANGE};
+static std::vector<std::vector<size_t>> pow2_range  = {POW2_RANGE};
+static std::vector<std::vector<size_t>> pow3_range  = {POW3_RANGE};
+static std::vector<std::vector<size_t>> pow5_range  = {POW5_RANGE};
 static std::vector<std::vector<size_t>> prime_range = {PRIME_RANGE};
 
 static size_t batch_range[] = {1};
 
 static size_t stride_range[] = {1}; // 1: assume packed data
 
-static rocfft_result_placement placeness_range[] = {
-    rocfft_placement_notinplace, rocfft_placement_inplace};
+static rocfft_result_placement placeness_range[]
+    = {rocfft_placement_notinplace, rocfft_placement_inplace};
 
-static rocfft_transform_type transform_range[] = {
-    rocfft_transform_type_complex_forward, rocfft_transform_type_complex_inverse};
+static rocfft_transform_type transform_range[]
+    = {rocfft_transform_type_complex_forward, rocfft_transform_type_complex_inverse};
 
 static data_pattern pattern_range[] = {sawtooth};
 
@@ -448,7 +448,6 @@ INSTANTIATE_TEST_CASE_P(rocfft_prime_2D,
                                 ValuesIn(transform_range),
                                 ValuesIn(stride_range),
                                 ValuesIn(pattern_range)));
-
 
 // *****************************************************
 // REAL  HERMITIAN

--- a/library/src/include/ref_cpu.h
+++ b/library/src/include/ref_cpu.h
@@ -171,8 +171,6 @@ public:
             freedata();
         }
         data = (void*)(*local_fftwf_malloc)(typesize * size);
-        std::cout << typesize << std::endl;
-        std::cout << size << std::endl;
         assert(data != NULL);
     }
     size_t bufsize()

--- a/library/src/include/ref_cpu.h
+++ b/library/src/include/ref_cpu.h
@@ -255,7 +255,7 @@ class RefLibOp
         fftwin.alloc(insize, in_typesize);
         fftwout.alloc(outsize, out_typesize);
         libout.alloc(outsize, out_typesize);
-        
+
         memset(fftwin.data, 0x40, fftwin.bufsize());
         memset(fftwout.data, 0x40, fftwout.bufsize());
         memset(libout.data, 0x40, libout.bufsize());

--- a/library/src/include/ref_cpu.h
+++ b/library/src/include/ref_cpu.h
@@ -136,7 +136,7 @@ private:
 
 public:
     fftwbuf()
-        : data(0)
+        : data(NULL)
         , size(0)
         , typesize(0)
     {
@@ -166,11 +166,14 @@ public:
     {
         size     = size0;
         typesize = typesize0;
-        if(data != 0)
+        if(data != NULL)
         {
             freedata();
         }
         data = (void*)(*local_fftwf_malloc)(typesize * size);
+        std::cout << typesize << std::endl;
+        std::cout << size << std::endl;
+        assert(data != NULL);
     }
     size_t bufsize()
     {
@@ -221,7 +224,8 @@ class RefLibOp
         case CS_KERNEL_FFT_MUL:
         case CS_KERNEL_PAD_MUL:
         case CS_KERNEL_RES_MUL:
-            insize = std::accumulate(data->node->length.begin(),
+            // NB: the Bluestein length is the first dimesion
+            insize = std::accumulate(data->node->length.begin() + 1,
                                      data->node->length.end(),
                                      batch,
                                      std::multiplies<size_t>());
@@ -253,7 +257,7 @@ class RefLibOp
         fftwin.alloc(insize, in_typesize);
         fftwout.alloc(outsize, out_typesize);
         libout.alloc(outsize, out_typesize);
-
+        
         memset(fftwin.data, 0x40, fftwin.bufsize());
         memset(fftwout.data, 0x40, fftwout.bufsize());
         memset(libout.data, 0x40, libout.bufsize());

--- a/library/src/plan.cpp
+++ b/library/src/plan.cpp
@@ -1591,7 +1591,15 @@ void TreeNode::TraverseTreeAssignBuffersLogicA(OperatingBuffer& flipIn,
         size_t cs = childNodes[1]->childNodes.size();
         if(cs)
         {
-            assert(childNodes[1]->childNodes[0]->obIn == OB_TEMP_CMPLX_FOR_REAL);
+            if(childNodes[1]->scheme == CS_BLUESTEIN)
+            {
+                assert(childNodes[1]->childNodes[0]->obIn == OB_TEMP_BLUESTEIN);
+                assert(childNodes[1]->childNodes[1]->obIn == OB_TEMP_CMPLX_FOR_REAL);
+            }
+            else
+            {
+                assert(childNodes[1]->childNodes[0]->obIn == OB_TEMP_CMPLX_FOR_REAL);
+            }
             assert(childNodes[1]->childNodes[cs - 1]->obOut == OB_TEMP_CMPLX_FOR_REAL);
         }
 

--- a/library/src/plan.cpp
+++ b/library/src/plan.cpp
@@ -1656,6 +1656,8 @@ void TreeNode::TraverseTreeAssignBuffersLogicA(OperatingBuffer& flipIn,
     break;
     case CS_BLUESTEIN:
     {
+        assert(childNodes.size() == 7);
+
         OperatingBuffer savFlipIn  = flipIn;
         OperatingBuffer savFlipOut = flipOut;
         OperatingBuffer savOutBuf  = obOutBuf;
@@ -1664,19 +1666,21 @@ void TreeNode::TraverseTreeAssignBuffersLogicA(OperatingBuffer& flipIn,
         flipOut  = OB_TEMP;
         obOutBuf = OB_TEMP_BLUESTEIN;
 
-        obIn  = (parent == nullptr) ? OB_USER_IN : savFlipIn;
-        obOut = (parent == nullptr)
-                    ? (placement == rocfft_placement_inplace) ? OB_USER_IN : OB_USER_OUT
-                    : savOutBuf;
-
-        assert(childNodes.size() == 7);
-
         assert(childNodes[0]->scheme == CS_KERNEL_CHIRP);
         childNodes[0]->obIn  = OB_TEMP_BLUESTEIN;
         childNodes[0]->obOut = OB_TEMP_BLUESTEIN;
 
         assert(childNodes[1]->scheme == CS_KERNEL_PAD_MUL);
-        childNodes[1]->obIn  = obIn;
+        if(parent == nullptr)
+        {
+            childNodes[1]->obIn
+                = (placement == rocfft_placement_inplace) ? OB_USER_OUT : OB_USER_IN;
+        }
+        else
+        {
+            childNodes[1]->obIn = obIn;
+        }
+
         childNodes[1]->obOut = OB_TEMP_BLUESTEIN;
 
         childNodes[2]->obIn  = OB_TEMP_BLUESTEIN;
@@ -1697,7 +1701,10 @@ void TreeNode::TraverseTreeAssignBuffersLogicA(OperatingBuffer& flipIn,
 
         assert(childNodes[6]->scheme == CS_KERNEL_RES_MUL);
         childNodes[6]->obIn  = OB_TEMP_BLUESTEIN;
-        childNodes[6]->obOut = obOut;
+        childNodes[6]->obOut = (parent == nullptr) ? OB_USER_OUT : obOut;
+
+        obIn  = childNodes[1]->obIn;
+        obOut = childNodes[6]->obOut;
 
         flipIn   = savFlipIn;
         flipOut  = savFlipOut;


### PR DESCRIPTION
resolves #219 

Summary of proposed changes:
-  Restore Bluestein buffer logic
-  Handle more cases for debug-asserts with buffer placement
-  Add 2D prime-length test cases
- Fix Bluestein cpu reference buffer size computation
