### PR TITLE
Add numeric header to ref_cpu.h to fix compilation on Ubuntu 18.

### DIFF
--- a/library/src/include/ref_cpu.h
+++ b/library/src/include/ref_cpu.h
@@ -31,9 +31,8 @@
 #include <dlfcn.h>
 #include <functional>
 #include <iostream>
-#include <stdlib.h>
 #include <numeric>
-
+#include <stdlib.h>
 
 #define LOCAL_FFTW_FORWARD (-1)
 #define LOCAL_FFTW_BACKWARD (+1)

--- a/library/src/include/ref_cpu.h
+++ b/library/src/include/ref_cpu.h
@@ -32,6 +32,8 @@
 #include <functional>
 #include <iostream>
 #include <stdlib.h>
+#include <numeric>
+
 
 #define LOCAL_FFTW_FORWARD (-1)
 #define LOCAL_FFTW_BACKWARD (+1)


### PR DESCRIPTION
Summary of proposed changes:
-  Add numeric header to fix compilation on Ubuntu 18.04