### PR TITLE
Revert "Removed hip-clang job and added vega 10 centos job (#231)"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,8 @@ rocFFTCI:
     rocfft.paths.build_command = './install.sh -c'
 
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx900 && ubuntu', 'gfx906 && ubuntu', 'gfx900 && centos7', 'gfx906 && centos7'], rocfft)
+    def nodes = new dockerNodes(['gfx900 && ubuntu', 'gfx906 && ubuntu', 'gfx906 && centos7', 'gfx900 && ubuntu && hip-clang',
+                'gfx906 && ubuntu && hip-clang'], rocfft)
 
     boolean formatCheck = true
 


### PR DESCRIPTION
This reverts commit 80d0d7009ac9a7b853a4f7297ea40993e44948a8.

Summary of proposed changes:
-  Re-enable hip-clang CI
