### PR TITLE
Fix hip-clang build error. (#233)

### DIFF
--- a/clients/samples/hipfft/hipfft_planmany_2d_z2z.cpp
+++ b/clients/samples/hipfft/hipfft_planmany_2d_z2z.cpp
@@ -24,6 +24,7 @@
 #include <hip/hip_runtime_api.h>
 #include <hipfft.h>
 #include <iostream>
+#include <vector>
 
 int main()
 {

--- a/clients/samples/hipfft/hipfft_setworkarea.cpp
+++ b/clients/samples/hipfft/hipfft_setworkarea.cpp
@@ -24,6 +24,7 @@
 #include <hip/hip_runtime_api.h>
 #include <hipfft.h>
 #include <iostream>
+#include <vector>
 
 int main()
 {


### PR DESCRIPTION
- Add missing headers.

resolves #SWDEV-199418 as well as build failure in ci-master

Summary of proposed changes:
-  
-  
-  
