### PR TITLE
Wrong cmake command prevents manual setting of amdgpu-target

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -90,7 +90,7 @@ if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
   target_compile_options( rocfft PRIVATE -Wno-unused-command-line-argument )
 
   foreach( target ${AMDGPU_TARGETS} )
-    target_link_libraries( rocfft PRIVATE --amdgpu-target=${target} )
+    target_compile_options( rocfft PRIVATE --amdgpu-target=${target} )
   endforeach( )
 else( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
   cuda_find_samples_inc_dir( cuda_samples_inc_dir )

--- a/library/src/device/CMakeLists.txt
+++ b/library/src/device/CMakeLists.txt
@@ -103,7 +103,7 @@ if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
   target_compile_options( rocfft-device PRIVATE -Wno-unused-command-line-argument )
 
   foreach( target ${AMDGPU_TARGETS} )
-    target_link_libraries( rocfft-device PRIVATE --amdgpu-target=${target} )
+    target_compile_options( rocfft-device PRIVATE --amdgpu-target=${target} )
   endforeach( )
 endif( )
 


### PR DESCRIPTION
Summary of proposed changes:
- changed "target_link_libraries" to "target_compile_options"
- without that option AMDGPU_TARGETS is not recognized

