### PR TITLE
Fix index 0 calculation c2r prekernel to deal with non-zero imaginary part

### DIFF
--- a/library/src/device/real2complex.cpp
+++ b/library/src/device/real2complex.cpp
@@ -392,8 +392,8 @@ __global__ void real_1d_pre_post_process_kernel(size_t   half_N,
         {
             T p             = input[0];
             T q             = input[half_N];
-            output[idx_p].x = p.x + q.x;
-            output[idx_p].y = p.x - q.x;
+            output[idx_p].x = p.x - p.y + q.x + q.y;
+            output[idx_p].y = p.x + p.y - q.x - q.y;
         }
     }
     else if(idx_p <= half_N >> 1)


### PR DESCRIPTION
The real-to-complex pre-processing kernel incorrectly assumed that the first and last index had
zero imaginary part, which may not be true when used to pre-process or 2D and 3D transforms.

Summary of proposed changes:
-  Account for imaginary part for index-0 computations in real_1d_pre_post_process_kernel