### PR TITLE
Master rocm 2.8 hip on windows

### DIFF
--- a/clients/rider/CMakeLists.txt
+++ b/clients/rider/CMakeLists.txt
@@ -80,17 +80,26 @@ if( CUDA_FOUND )
   target_compile_definitions( rocfft-rider PRIVATE __HIP_PLATFORM_NVCC__ )
   target_link_libraries( rocfft-rider PRIVATE ${CUDA_LIBRARIES} )
 else( )
-  target_link_libraries( rocfft-rider PRIVATE hip::hip_hcc )
+  if( NOT WIN32 )
+    target_link_libraries( rocfft-rider PRIVATE hip::hip_hcc )
+  endif( )
 endif( )
 
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-  target_compile_options( rocfft-rider PRIVATE -Wno-unused-command-line-argument -hc)
+  target_compile_options( rocfft-rider PRIVATE -Wno-unused-command-line-argument )
 
   # foreach( target ${AMDGPU_TARGETS} )
   #   target_link_libraries( rocfft-rider PRIVATE --amdgpu-target=${target} )
   # endforeach( )
+endif( )
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+  target_compile_options( rocfft-rider PRIVATE -hc)
+endif( )
+if( HIP_PLATFORM STREQUAL "hip-clang" )
+  # Avoid warnings due to __declspec attribute 'dllexport' with clang
+  target_compile_options( rocfft-rider PRIVATE "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-unknown-attributes" )
 endif( )
 
 set_target_properties( rocfft-rider PROPERTIES DEBUG_POSTFIX "-d" CXX_EXTENSIONS NO )

--- a/clients/rider/rider.h
+++ b/clients/rider/rider.h
@@ -5,92 +5,31 @@
 #ifndef RIDER_H
 #define RIDER_H
 
+#include <chrono>
+
 //	Boost headers that we want to use
-//	#define BOOST_PROGRAM_OPTIONS_DYN_LINK
+#define BOOST_PROGRAM_OPTIONS_DYN_LINK
 #include <boost/program_options.hpp>
 
-#ifdef WIN32
-
 struct Timer
 {
-    LARGE_INTEGER start, stop, freq;
-
-public:
-    Timer()
-    {
-        QueryPerformanceFrequency(&freq);
-    }
-
-    void Start()
-    {
-        QueryPerformanceCounter(&start);
-    }
-    double Sample()
-    {
-        QueryPerformanceCounter(&stop);
-        double time = (double)(stop.QuadPart - start.QuadPart) / (double)(freq.QuadPart);
-        return time;
-    }
-};
-
-#elif defined(__APPLE__) || defined(__MACOSX)
-
-#include <mach/mach.h>
-
-#include <mach/clock.h>
-
-struct Timer
-{
-    clock_serv_t    clock;
-    mach_timespec_t start, end;
-
-public:
-    Timer()
-    {
-        host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &clock);
-    }
-    ~Timer()
-    {
-        mach_port_deallocate(mach_task_self(), clock);
-    }
-
-    void Start()
-    {
-        clock_get_time(clock, &start);
-    }
-    double Sample()
-    {
-        clock_get_time(clock, &end);
-        double time = 1000000000L * (end.tv_sec - start.tv_sec) + end.tv_nsec - start.tv_nsec;
-        return time * 1E-9;
-    }
-};
-
-#else
-
-#include <time.h>
-
-#include <cmath>
-
-struct Timer
-{
-    struct timespec start, end;
+    std::chrono::time_point<std::chrono::system_clock> start, end;
 
 public:
     Timer() {}
 
     void Start()
     {
-        clock_gettime(CLOCK_MONOTONIC, &start);
+        start = std::chrono::system_clock::now();
     }
+
     double Sample()
     {
-        clock_gettime(CLOCK_MONOTONIC, &end);
-        double time = 1000000000L * (end.tv_sec - start.tv_sec) + end.tv_nsec - start.tv_nsec;
-        return time * 1E-9;
+        end                                   = std::chrono::system_clock::now();
+        std::chrono::duration<double> elapsed = end - start;
+        // Return elapsed time in seconds
+        return elapsed.count();
     }
 };
-
-#endif
 
 #endif // RIDER_H

--- a/clients/samples/fixed-16/CMakeLists.txt
+++ b/clients/samples/fixed-16/CMakeLists.txt
@@ -60,17 +60,26 @@ foreach( sample ${sample_list} )
     target_compile_definitions( ${sample} PRIVATE __HIP_PLATFORM_NVCC__ )
     target_link_libraries( ${sample} PRIVATE ${CUDA_LIBRARIES} )
   else( )
-    target_link_libraries( ${sample} PRIVATE hip::hip_hcc )
+    if( NOT WIN32 )
+      target_link_libraries( ${sample} PRIVATE hip::hip_hcc )
+    endif( )
   endif( )
 
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
     # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-    target_compile_options( ${sample} PRIVATE -Wno-unused-command-line-argument -hc)
+    target_compile_options( ${sample} PRIVATE -Wno-unused-command-line-argument )
 
     # foreach( target ${AMDGPU_TARGETS} )
     #   target_link_libraries( ${sample} PRIVATE --amdgpu-target=${target} )
     # endforeach( )
+  endif( )
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+    target_compile_options( ${sample} PRIVATE -hc)
+  endif( )
+  if( HIP_PLATFORM STREQUAL "hip-clang" )
+    # Avoid warnings due to __declspec attribute 'dllexport' with clang
+    target_compile_options( ${sample} PRIVATE "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-unknown-attributes" )
   endif( )
 
 endforeach( )

--- a/clients/samples/fixed-large/CMakeLists.txt
+++ b/clients/samples/fixed-large/CMakeLists.txt
@@ -60,18 +60,27 @@ foreach( sample ${sample_list} )
     target_compile_definitions( ${sample} PRIVATE __HIP_PLATFORM_NVCC__ )
     target_link_libraries( ${sample} PRIVATE ${CUDA_LIBRARIES} )
   else( )
-    target_link_libraries( ${sample} PRIVATE hip::hip_hcc )
+    if( NOT WIN32 )
+      target_link_libraries( ${sample} PRIVATE hip::hip_hcc )
+    endif( )
   endif( )
 
 
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
     # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-    target_compile_options( ${sample} PRIVATE -Wno-unused-command-line-argument -hc)
+    target_compile_options( ${sample} PRIVATE -Wno-unused-command-line-argument )
 
     # foreach( target ${AMDGPU_TARGETS} )
     #   target_link_libraries( ${sample} PRIVATE --amdgpu-target=${target} )
     # endforeach( )
+  endif( )
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+    target_compile_options( ${sample} PRIVATE -hc)
+  endif( )
+  if( HIP_PLATFORM STREQUAL "hip-clang" )
+    # Avoid warnings due to __declspec attribute 'dllexport' with clang
+    target_compile_options( ${sample} PRIVATE "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-unknown-attributes" )
   endif( )
 
 endforeach( )

--- a/clients/samples/hipfft/CMakeLists.txt
+++ b/clients/samples/hipfft/CMakeLists.txt
@@ -23,10 +23,17 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 find_package(hip)
-find_package(rocfft)
+if( NOT WIN32 )
+  find_package(rocfft)
+endif( )
 
 set( sample_list hipfft_1d_z2z hipfft_1d_d2z hipfft_2d_z2z hipfft_2d_d2z hipfft_3d_z2z
   hipfft_3d_d2z hipfft_planmany_2d_z2z hipfft_planmany_2d_r2c hipfft_setworkarea)
+
+
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+  set(CMAKE_CXX_FLAG = "${CMAKE_CXX_FLAG} -hc")
+endif( )
 
 foreach( sample ${sample_list} )
 
@@ -52,17 +59,26 @@ foreach( sample ${sample_list} )
     target_compile_definitions( ${sample} PRIVATE __HIP_PLATFORM_NVCC__ )
     target_link_libraries( ${sample} PRIVATE ${CUDA_LIBRARIES} )
   else( )
-    target_link_libraries( ${sample} PRIVATE hip::hip_hcc )
+    if( NOT WIN32 )
+      target_link_libraries( ${sample} PRIVATE hip::hip_hcc )
+    endif( )
   endif( )
 
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
     # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-    target_compile_options( ${sample} PRIVATE -Wno-unused-command-line-argument -hc)
+    target_compile_options( ${sample} PRIVATE -Wno-unused-command-line-argument )
 
     # foreach( target ${AMDGPU_TARGETS} )
     #   target_link_libraries( ${sample} PRIVATE --amdgpu-target=${target} )
     # endforeach( )
+  endif( )
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+    target_compile_options( ${sample} PRIVATE -hc)
+  endif( )
+  if( HIP_PLATFORM STREQUAL "hip-clang" )
+    # Avoid warnings due to __declspec attribute 'dllexport' with clang
+    target_compile_options( ${sample} PRIVATE "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-unknown-attributes" )
   endif( )
 
 endforeach( )

--- a/clients/samples/hipfft/CMakeLists.txt
+++ b/clients/samples/hipfft/CMakeLists.txt
@@ -23,9 +23,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 find_package(hip)
-if( NOT WIN32 )
-  find_package(rocfft)
-endif( )
+#find_package(rocfft)
 
 set( sample_list hipfft_1d_z2z hipfft_1d_d2z hipfft_2d_z2z hipfft_2d_d2z hipfft_3d_z2z
   hipfft_3d_d2z hipfft_planmany_2d_z2z hipfft_planmany_2d_r2c hipfft_setworkarea)

--- a/clients/selftest/CMakeLists.txt
+++ b/clients/selftest/CMakeLists.txt
@@ -79,17 +79,26 @@ if( CUDA_FOUND )
   target_compile_definitions( rocfft-selftest PRIVATE __HIP_PLATFORM_NVCC__ )
   target_link_libraries( rocfft-selftest PRIVATE ${CUDA_LIBRARIES} )
 else( )
-  target_link_libraries( rocfft-selftest PRIVATE hip::hip_hcc )
+  if( NOT WIN32 )
+    target_link_libraries( rocfft-selftest PRIVATE hip::hip_hcc )
+  endif( )
 endif( )
 
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-  target_compile_options( rocfft-selftest PRIVATE -Wno-unused-command-line-argument -hc)
+  target_compile_options( rocfft-selftest PRIVATE -Wno-unused-command-line-argument )
 
   # foreach( target ${AMDGPU_TARGETS} )
   #   target_link_libraries( rocfft-selftest PRIVATE --amdgpu-target=${target} )
   # endforeach( )
+endif( )
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+  target_compile_options( rocfft-selftest PRIVATE -hc)
+endif( )
+if( HIP_PLATFORM STREQUAL "hip-clang" )
+  # Avoid warnings due to __declspec attribute 'dllexport' with clang
+  target_compile_options( rocfft-selftest PRIVATE "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-unknown-attributes" )
 endif( )
 
 set( THREADS_PREFER_PTHREAD_FLAG ON )

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -88,6 +88,7 @@ target_include_directories( rocfft-test
     $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${FFTW_INCLUDES}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/misc/include>
+    ${FFTW_INCLUDE_DIRS}
 )
 
 target_link_libraries( rocfft-test PRIVATE roc::rocfft ${GTEST_LIBRARIES} ${FFTW_LIBRARIES} ${Boost_LIBRARIES} )
@@ -101,17 +102,26 @@ if( CUDA_FOUND )
   target_compile_definitions( rocfft-test PRIVATE __HIP_PLATFORM_NVCC__ )
   target_link_libraries( rocfft-test PRIVATE ${CUDA_LIBRARIES} )
 else( )
-  target_link_libraries( rocfft-test PRIVATE hip::hip_hcc )
+  if( NOT WIN32 )
+    target_link_libraries( rocfft-test PRIVATE hip::hip_hcc )
+  endif( )
 endif( )
 
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-  target_compile_options( rocfft-test PRIVATE -Wno-unused-command-line-argument -hc)
+  target_compile_options( rocfft-test PRIVATE -Wno-unused-command-line-argument )
 
   # foreach( target ${AMDGPU_TARGETS} )
   #   target_link_libraries( rocfft-test PRIVATE --amdgpu-target=${target} )
   # endforeach( )
+endif( )
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+  target_compile_options( rocfft-test PRIVATE -hc)
+endif( )
+if( HIP_PLATFORM STREQUAL "hip-clang" )
+  # Avoid warnings due to __declspec attribute 'dllexport' with clang
+  target_compile_options( rocfft-test PRIVATE "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-unknown-attributes" )
 endif( )
 
 set( THREADS_PREFER_PTHREAD_FLAG ON )

--- a/clients/tests/accuracy_test_1D.cpp
+++ b/clients/tests/accuracy_test_1D.cpp
@@ -20,10 +20,11 @@
 * THE SOFTWARE.
 *******************************************************************************/
 
+#include <chrono>
 #include <gtest/gtest.h>
 #include <math.h>
 #include <stdexcept>
-#include <unistd.h>
+#include <thread>
 #include <vector>
 
 #include "fftw_transform.h"
@@ -169,7 +170,7 @@ void normal_1D_complex_interleaved_to_complex_interleaved(size_t                
                                   in_array_type,
                                   out_array_type,
                                   placeness);
-    usleep(1e4);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
 }
 
 // *****************************************************
@@ -250,7 +251,7 @@ void normal_1D_real_interleaved_to_hermitian_interleaved(size_t                 
                                  out_array_type,
                                  rocfft_placement_notinplace); // must be non-inplace tranform
 
-    usleep(1e4);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
 }
 
 TEST_P(accuracy_test_real, normal_1D_real_interleaved_to_hermitian_interleaved_single_precision)
@@ -329,7 +330,7 @@ void normal_1D_hermitian_interleaved_to_real_interleaved(size_t                 
                                  out_array_type,
                                  rocfft_placement_notinplace); // must be non-inplace tranform
 
-    usleep(1e4);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
 }
 
 TEST_P(accuracy_test_real, normal_1D_hermitian_interleaved_to_real_interleaved_single_precision)

--- a/clients/tests/accuracy_test_2D.cpp
+++ b/clients/tests/accuracy_test_2D.cpp
@@ -20,10 +20,11 @@
 * THE SOFTWARE.
 *******************************************************************************/
 
+#include <chrono>
 #include <gtest/gtest.h>
 #include <math.h>
 #include <stdexcept>
-#include <unistd.h>
+#include <thread>
 #include <vector>
 
 #include "fftw_transform.h"
@@ -198,7 +199,7 @@ void normal_2D_complex_interleaved_to_complex_interleaved(std::vector<size_t>   
                                   in_array_type,
                                   out_array_type,
                                   placeness);
-    usleep(1e4);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
 }
 
 // *****************************************************
@@ -283,7 +284,7 @@ void normal_2D_real_interleaved_to_hermitian_interleaved(std::vector<size_t>    
                                  out_array_type,
                                  rocfft_placement_notinplace); // must be non-inplace tranform
 
-    usleep(1e4);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
 }
 
 TEST_P(accuracy_test_real_2D, normal_2D_real_interleaved_to_hermitian_interleaved_single_precision)
@@ -362,7 +363,7 @@ void normal_2D_hermitian_interleaved_to_real_interleaved(std::vector<size_t>    
                                  out_array_type,
                                  rocfft_placement_notinplace); // must be non-inplace tranform
 
-    usleep(1e4);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
 }
 
 TEST_P(accuracy_test_real_2D, normal_2D_hermitian_interleaved_to_real_interleaved_single_precision)

--- a/clients/tests/hipfft_test.cpp
+++ b/clients/tests/hipfft_test.cpp
@@ -27,7 +27,6 @@
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
 #include <hip/hip_vector_types.h>
-#include <unistd.h>
 #include <vector>
 
 TEST(hipfftTest, Create1dPlan)

--- a/clients/tests/template.cpp
+++ b/clients/tests/template.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 #include <stdexcept>
-#include <unistd.h>
 
 #include "rocfft_transform.h"
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -32,7 +32,7 @@
 function( target_compile_features target_name )
   # With Cmake v3.5, hipcc (with nvcc backend) does not work with target_compile_features
   # Turn on -std=c++11 manually
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc*" )
     set_target_properties( ${target_name} PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON )
   else( )
     _target_compile_features( ${target_name} ${ARGN} )
@@ -45,7 +45,7 @@ endfunction( )
 function( target_link_libraries target_name )
   # hipcc takes care of finding hip library dependencies internally; remove
   # explicit mentions of them so cmake doesn't complain on nvcc path
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" AND NOT USE_HIP_CLANG)
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc*" AND NOT USE_HIP_CLANG)
     foreach( link_library ${ARGN} )
       if( (link_library MATCHES "^hip::|^hcc::") )
       else( )
@@ -136,8 +136,10 @@ add_subdirectory( src )
 # endif( )
 
 # Package specific CPACK vars
-set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.3)" )
-set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.3" )
+if( NOT WIN32 )
+  set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.3)" )
+  set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.3" )
+endif( )
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
 
 if( NOT CPACK_PACKAGING_INSTALL_PREFIX )

--- a/library/include/hipfft.h
+++ b/library/include/hipfft.h
@@ -26,7 +26,11 @@
 #include <hip/hip_complex.h>
 #include <hip/hip_runtime_api.h>
 
+#ifdef _WIN32
+#define DLL_PUBLIC __declspec(dllexport)
+#else
 #define DLL_PUBLIC __attribute__((visibility("default")))
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/library/include/rocfft.h
+++ b/library/include/rocfft.h
@@ -34,7 +34,9 @@
 extern "C" {
 #endif // __cplusplus
 
+#ifndef _WIN32
 #include <cstddef>
+#endif
 
 /*! @brief Pointer type to plan structure
  *  @details This type is used to declare a plan handle that can be initialized

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -95,6 +95,10 @@ if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
 else( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
   cuda_find_samples_inc_dir( cuda_samples_inc_dir )
 endif( )
+if( HIP_PLATFORM STREQUAL "hip-clang" )
+  # Avoid warnings due to __declspec attribute 'dllexport' with clang
+  target_compile_options( rocfft PRIVATE "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-unknown-attributes" )
+endif( )
 
 target_include_directories( rocfft
   PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/library/src/include>
@@ -117,6 +121,16 @@ generate_export_header( rocfft EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/ro
 # Following Boost conventions of prefixing 'lib' on static built libraries, across all platforms
 if( NOT BUILD_SHARED_LIBS )
   set_target_properties( rocfft PROPERTIES PREFIX "lib" )
+endif( )
+
+# This is needed on Windows only
+if( WIN32 )
+  add_custom_command(TARGET rocfft
+                     POST_BUILD
+                     COMMAND ${CMAKE_COMMAND} -E copy
+		     ${PROJECT_BINARY_DIR}/staging/rocfft.lib
+		     ${PROJECT_BINARY_DIR}/library/src/rocfft.lib
+  )
 endif( )
 
 ############################################################

--- a/library/src/device/CMakeLists.txt
+++ b/library/src/device/CMakeLists.txt
@@ -77,14 +77,26 @@ set( rocfft_device_source
 
 prepend_path( "../.." rocfft_headers_public relative_rocfft_device_headers_public )
 
-add_library( rocfft-device
-  ${rocfft_device_source}
-  ${relative_rocfft_device_headers_public}
-  ${gen_headers}
-  )
+if( WIN32 )
+  add_library( rocfft-device STATIC
+    ${rocfft_device_source}
+    ${relative_rocfft_device_headers_public}
+    ${gen_headers}
+    )
+else( )
+  add_library( rocfft-device
+    ${rocfft_device_source}
+    ${relative_rocfft_device_headers_public}
+    ${gen_headers}
+    )
+endif( )
 add_library( roc::rocfft-device ALIAS rocfft-device )
 target_compile_features( rocfft-device PRIVATE cxx_static_assert cxx_nullptr cxx_auto_type )
 target_compile_options (rocfft-device PRIVATE -fno-gpu-rdc)
+if( HIP_PLATFORM STREQUAL "hip-clang" )
+  # Avoid warnings due to __declspec attribute 'dllexport' with clang
+  target_compile_options( rocfft-device PRIVATE "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-unknown-attributes" )
+endif( )
 
 # Remove this check when we no longer build with older rocm stack(ie < 1.8.2)
 if(TARGET hip::device)

--- a/library/src/device/generator/CMakeLists.txt
+++ b/library/src/device/generator/CMakeLists.txt
@@ -8,6 +8,11 @@ target_compile_features( rocfft-kernel-generator PRIVATE cxx_static_assert cxx_n
 set_target_properties( rocfft-kernel-generator PROPERTIES CXX_EXTENSIONS NO )
 set_target_properties( rocfft-kernel-generator PROPERTIES DEBUG_POSTFIX "-d" )
 
+if( HIP_PLATFORM STREQUAL "hip-clang" )
+  # Avoid warnings due to __declspec attribute 'dllexport' with clang
+  target_compile_options( rocfft-kernel-generator PRIVATE "-Wno-ignored-attributes -Wno-deprecated-declarations -Wno-unknown-attributes" )
+endif( )
+
 target_include_directories( rocfft-kernel-generator
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>

--- a/library/src/include/kernel_launch.h
+++ b/library/src/include/kernel_launch.h
@@ -24,7 +24,9 @@
 #define KERNEL_LAUNCH_SINGLE
 
 #define FN_PRFX(X) rocfft_internal_##X
+#ifndef __clang__
 #include "error.h"
+#endif
 #include "kargs.h"
 #include "kernel_launch_generator.h"
 #include "rocfft.h"

--- a/library/src/include/private.h
+++ b/library/src/include/private.h
@@ -23,7 +23,11 @@
 #ifndef __ROCFFT_PRIVATE_H__
 #define __ROCFFT_PRIVATE_H__
 
+#ifdef _WIN32
+#define DLL_PUBLIC __declspec(dllexport)
+#else
 #define DLL_PUBLIC __attribute__((visibility("default")))
+#endif
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus

--- a/library/src/include/twiddles.h
+++ b/library/src/include/twiddles.h
@@ -109,8 +109,8 @@ public:
         size_t nt = 0;
         for(size_t i = 0; i < N; i++)
         {
-            double c, s;
-            sincos(TWO_PI * i / N, &s, &c);
+            double c = cos(TWO_PI * i / N);
+            double s = sin(TWO_PI * i / N);
 
             wc[nt].x = c;
             wc[nt].y = s;


### PR DESCRIPTION
The purpose of this PR is to enable compilation of rocFFT using Hip-Clang on Windows.

Summary of proposed changes:
- library/CMakeLists.txt
- library/src/CMakeLists.txt
- library/src/device/CMakeLists.txt
- library/src/device/generator/CMakeLists.txt
- clients/rider/CMakeLists.txt
- clients/samples/fixed-16/CMakeLists.txt
- clients/samples/fixed-large/CMakeLists.txt
- clients/samples/hipfft/CMakeLists.txt
- clients/selftest/CMakeLists.txt
- clients/tests/CMakeLists.txt

- library/include/hipfft.h
- library/include/rocfft.h
- library/src/include/kernel_launch.h
- library/src/include/private.h
- library/src/include/twiddles.h
- clients/rider/rider.h

- clients/tests/accuracy_test_1D.cpp
- clients/tests/accuracy_test_2D.cpp
- clients/tests/hipfft_test.cpp
- clients/tests/template.cpp
