### PR TITLE
Fixed clang-format file for rocm2.8 (#10)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -103,6 +103,7 @@ PointerAlignment: Left
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: Never
+SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false


### PR DESCRIPTION
Fixed clang-format file for rocm2.8