### PR TITLE
rocFFT - Changes to support multiple ROCM installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,13 +93,13 @@ elseif( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
   set( CMAKE_C_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN "-Xcompiler ${CMAKE_C_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN}" )
   set( CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN "-Xcompiler ${CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN}" )
 elseif( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
-  message( STATUS "HCC compiler set; ROCm backend selected [ CXX=/opt/rocm/bin/hcc cmake ... ]" )
+  message( STATUS "HCC compiler set; ROCm backend selected [ CXX=/opt/rocm-<ver>/bin/hcc cmake ... ]" )
 endif( )
 
 # This finds the rocm-cmake project, and installs it if not found
 # rocm-cmake contains common cmake code for rocm projects to help setup and install
 set( PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern )
-find_package( ROCM CONFIG QUIET PATHS /opt/rocm )
+find_package( ROCM CONFIG QUIET PATHS ${CMAKE_INSTALL_PREFIX} )
 if( NOT ROCM_FOUND )
   set( rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download" )
   file( DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
@@ -126,7 +126,7 @@ rocm_setup_version( VERSION ${VERSION_STRING} )
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 
 # NOTE:  workaround until hcc & hip cmake modules fixes symlink logic in their config files; remove when fixed
-list( APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc /opt/rocm/hip )
+list( APPEND CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX}/hcc ${CMAKE_INSTALL_PREFIX}/hip )
 
 # Enable verbose output
 option( BUILD_VERBOSE "Output additional build information" OFF )
@@ -143,11 +143,11 @@ set(CMAKE_INSTALL_LIBDIR "lib" CACHE INTERNAL "Installation directory for librar
 # Find HCC/HIP dependencies
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
   message( STATUS "Building with ROCm tools" )
-  find_package( hcc REQUIRED CONFIG PATHS /opt/rocm )
+  find_package( hcc REQUIRED CONFIG PATHS ${CMAKE_INSTALL_PREFIX} )
 endif( )
 
 # Hip headers required of all clients; clients use hip to allocate device memory
-find_package( hip REQUIRED CONFIG PATHS /opt/rocm )
+find_package( hip REQUIRED CONFIG PATHS ${CMAKE_INSTALL_PREFIX} )
 
 # Quietly look for CUDA, but if not found it's not an error
 # The presense of hip is not sufficient to determine if we want a rocm or cuda backend

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -51,11 +51,11 @@ set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 # if rocfft is not a target, then we know clients are built separately from the library and we must search
 # for the rocfft package
 if( NOT TARGET rocfft )
-  find_package( rocfft REQUIRED CONFIG PATHS /opt/rocm/rocfft )
+  find_package( rocfft REQUIRED CONFIG PATHS ${CMAKE_INSTALL_PREFIX}/rocfft )
 endif( )
 
 # Hip headers required of all clients; clients use hip to allocate device memory
-find_package( hip REQUIRED CONFIG PATHS /opt/rocm )
+find_package( hip REQUIRED CONFIG PATHS ${CMAKE_INSTALL_PREFIX} )
 
 # Quietly look for CUDA, but if not found it's not an error
 # The presense of hip is not sufficient to determine if we want a rocm or cuda backend
@@ -101,12 +101,12 @@ function(rocm_create_package_clients)
     if(EXISTS "${PROJECT_BINARY_DIR}/package")
         file(REMOVE_RECURSE "${PROJECT_BINARY_DIR}/package")
     endif()
-    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/package/opt/rocm/${PARSE_LIB_NAME}/clients")
+    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/clients")
     file(WRITE "${PROJECT_BINARY_DIR}/package/DEBIAN/control" ${DEB_CONTROL_FILE_CONTENT})
 
     add_custom_target(package_clients
-        COMMAND ${CMAKE_COMMAND} -E remove -f "${PROJECT_BINARY_DIR}/package/opt/rocm/${PARSE_LIB_NAME}/clients/*"
-        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/*" "${PROJECT_BINARY_DIR}/package/opt/rocm/${PARSE_LIB_NAME}/clients"
+        COMMAND ${CMAKE_COMMAND} -E remove -f "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/clients/*"
+        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/*" "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/clients"
         COMMAND dpkg -b "${PROJECT_BINARY_DIR}/package/"  ${PACKAGE_NAME})
 endfunction(rocm_create_package_clients)
 

--- a/cmake/package-functions.cmake
+++ b/cmake/package-functions.cmake
@@ -11,7 +11,7 @@ file( WRITE ${scripts_write_dir}/postinst
 set -e
 
 do_ldconfig() {
-  echo ${CPACK_PACKAGING_INSTALL_PREFIX}/${LIB_INSTALL_DIR} > ${ld_conf_file} && ldconfig
+  echo /opt/rocm/${LIB_INSTALL_DIR} > ${ld_conf_file} && ldconfig
 }
 
 do_softlinks() {

--- a/install.sh
+++ b/install.sh
@@ -269,6 +269,10 @@ build_clients=false
 build_cuda=false
 build_release=true
 
+if ! [ -z ${ROCM_PATH+x} ]; then
+    install_prefix=${ROCM_PATH}
+fi
+
 # #################################################
 # Parameter parsing
 # #################################################
@@ -368,6 +372,9 @@ fi
 # We append customary rocm path; if user provides custom rocm path in ${path}, our
 # hard-coded path has lesser priority
 export PATH=${PATH}:/opt/rocm/bin
+if ! [ -z ${ROCM_PATH+x} ]; then
+    export PATH=${PATH}:${ROCM_PATH}/bin
+fi
 
 pushd .
 # #################################################
@@ -404,9 +411,9 @@ if [[ "${build_cuda}" == false ]]; then
 
     # Build library with AMD toolchain because of existense of device kernels
     if [[ "${build_clients}" == true ]]; then
-        CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX=${install_prefix} -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm ../..
+        CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX=${install_prefix} -DCPACK_PACKAGING_INSTALL_PREFIX=${install_prefix} ../..
     else
-        CXX=${compiler} ${cmake_executable} ${cmake_common_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX=${install_prefix} -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm ../..
+        CXX=${compiler} ${cmake_executable} ${cmake_common_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX=${install_prefix} -DCPACK_PACKAGING_INSTALL_PREFIX=${install_prefix} ../..
     fi
     check_exit_code
     make -j$(nproc)
@@ -433,7 +440,7 @@ else
     # with a different compiler on each.
 
     # Build library only with hipcc as compiler
-    CXX=${compiler} ${cmake_executable} ${cmake_common_options} -DCMAKE_INSTALL_PREFIX=${install_prefix} -DCPACK_PACKAGE_INSTALL_DIRECTORY=/opt/rocm ../..
+    CXX=${compiler} ${cmake_executable} ${cmake_common_options} -DCMAKE_INSTALL_PREFIX=${install_prefix} -DCPACK_PACKAGE_INSTALL_DIRECTORY=${install_prefix} ../..
     check_exit_code
     make -j$(nproc)
     check_exit_code

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -153,7 +153,7 @@ else( )
   set( package_name rocfft-alt )
 endif( )
 
-set( ROCFFT_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Path placed into ldconfig file" )
+set( ROCFFT_CONFIG_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Path placed into ldconfig file" )
 
 rocm_create_package(
     NAME ${package_name}

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -74,6 +74,12 @@ prepend_path( ".." rocfft_headers_public relative_rocfft_headers_public )
 
 add_library( rocfft ${rocfft_source} ${relative_rocfft_headers_public} )
 add_library( roc::rocfft ALIAS rocfft )
+
+# RUNPATH is set only when ROCM_RPATH is defined in the ENV
+if( DEFINED ENV{ROCM_RPATH} )
+  set ( CMAKE_SHARED_LINKER_FLAGS " -Wl,--enable-new-dtags -Wl,--rpath,$ENV{ROCM_RPATH}" )
+endif( )
+
 target_compile_features( rocfft PRIVATE cxx_static_assert cxx_nullptr cxx_auto_type )
 
 # Remove this check when we no longer build with older rocm stack(ie < 1.8.2)
@@ -86,7 +92,7 @@ target_link_libraries( rocfft PRIVATE rocfft-device )
 
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
-  # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
+  # "clang-5.0: warning: argument unused during compilation: '-isystem ${CMAKE_INSTALL_PREFIX}/include'"
   target_compile_options( rocfft PRIVATE -Wno-unused-command-line-argument )
 
   foreach( target ${AMDGPU_TARGETS} )

--- a/library/src/device/CMakeLists.txt
+++ b/library/src/device/CMakeLists.txt
@@ -99,7 +99,7 @@ endif()
 
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR HIP_PLATFORM STREQUAL "hip-clang")
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.1
-  # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
+  # "clang-5.0: warning: argument unused during compilation: '-isystem ${CMAKE_INSTALL_PREFIX}/include'"
   target_compile_options( rocfft-device PRIVATE -Wno-unused-command-line-argument )
 
   foreach( target ${AMDGPU_TARGETS} )


### PR DESCRIPTION
- Hard coded reference to /opt/rocm is parameterized
  to CMAKE_INSTALL_PREFIX
- Package is generated to install into ROCM_INSTALL_PATH if
  defined in the env otherwise default into /opt/rocm
- RUNPATH is set in the lib only if ROCM_RPATH env is defined
  with the rpath

Signed-off-by: Pruthvi Madugundu <mpruthvi@gmail.com>