### PR TITLE
force exit on unknown plan

### DIFF
--- a/library/src/hipfft.cpp
+++ b/library/src/hipfft.cpp
@@ -317,7 +317,7 @@ hipfftResult hipfftMakePlan_internal(hipfftHandle            plan,
                                         dry_run));
         break;
     default:
-        assert(false);
+        return HIPFFT_PARSE_ERROR;
     }
 
     size_t tmpBufferSize = 0;


### PR DESCRIPTION
So fun fact here -- since the distributed version of the rocFFT library appears to be built w/o debug symbols, there is no type checking of the value you pass in as a hipfftPlan ([assert becomes a no-op](https://en.cppreference.com/w/cpp/error/assert) w/ NDEBUG defined).

If you are unlucky enough to fall into this trap, trying to execute the plan later will result in no kernels being launched!

Bit of an edge use-case, but this set me back for hours trying to port a Fortran code that used cuFFT to hipFFT (because fortran enums suck, and can't handle the hex-values in hipfftType!).

Best,
Nick
