### PR TITLE
Fix CMAKE_INSTALL_PREFIX in build_relocatable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -428,7 +428,7 @@ if [[ "${build_cuda}" == false ]]; then
         cmake_client_options=" "
     fi
     if [[ "${build_relocatable}" == true ]]; then
-        CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX="${rocm_path}" -DCPACK_PACKAGING_INSTALL_PREFIX="${rocm_path}" \
+        CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX="${install_prefix}" -DCPACK_PACKAGING_INSTALL_PREFIX="${rocm_path}" \
         -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
         -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" \
         -DROCM_DISABLE_LDCONFIG=ON \


### PR DESCRIPTION
CMAKE_INSTALL_PREFIX need to set to ${install_prefix} so that check_install_dir ${install_prefix} makes sense.

Summary of proposed changes:

- CMAKE_INSTALL_PREFIX set to $install_prefix for 'make install'
- CPACK_PACKAGING_INSTALL_PREFIX still set to $rocm_path for package install path
- 'make install' can be called by non-root user to test the build