### PR TITLE
Change default compiler in install script to hipcc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -261,6 +261,7 @@ install_prefix=rocfft-install
 build_clients=false
 build_release=true
 build_relocatable=false
+build_hip_clang=true
 
 # #################################################
 # Parameter parsing

--- a/install.sh
+++ b/install.sh
@@ -399,10 +399,7 @@ if [[ "${build_clients}" == true ]]; then
     cmake_client_options="${cmake_client_options} -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON -DBUILD_CLIENTS_SELFTEST=ON -DBUILD_CLIENTS_RIDER=ON"
 fi
 
-compiler="hcc"
-if [[ "${build_hip_clang}" == true ]]; then
-    compiler="hipcc"
-fi
+compiler="hipcc"
 
 if [[ "${build_hip_clang}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DUSE_HIP_CLANG=ON -DHIP_COMPILER=clang"

--- a/install.sh
+++ b/install.sh
@@ -400,7 +400,10 @@ if [[ "${build_clients}" == true ]]; then
     cmake_client_options="${cmake_client_options} -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON -DBUILD_CLIENTS_SELFTEST=ON -DBUILD_CLIENTS_RIDER=ON"
 fi
 
-compiler="hipcc"
+compiler="hcc"
+if [[ "${build_hip_clang}" == true ]]; then
+    compiler="hipcc"
+fi
 
 if [[ "${build_hip_clang}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DUSE_HIP_CLANG=ON -DHIP_COMPILER=clang"


### PR DESCRIPTION
Targeting master-rocm-3.5 branch. As hcc will be deprecated for 3.5, this change will make installation easier for end users. Complete removal of hcc can be done in develop for 3.6