### PR TITLE
Fix including of <cstddef>.

### DIFF
--- a/library/include/hipfft.h
+++ b/library/include/hipfft.h
@@ -32,11 +32,11 @@
 #define DLL_PUBLIC __attribute__((visibility("default")))
 #endif
 
+#include <cstddef>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <cstddef>
 
 typedef enum hipfftResult_t
 {


### PR DESCRIPTION
- <cstddef> introduces C macros but, by itself, it's still a C++ header.

resolves SWDEV-241666
