### PR TITLE
 use appropriate find_package calls for HIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,12 +115,12 @@ set(CMAKE_INSTALL_LIBDIR "lib" CACHE INTERNAL
 # Find HCC/HIP dependencies
 if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
   message( STATUS "Building with ROCm tools" )
-  find_package( hip REQUIRED CONFIG PATHS )
+  find_package( HIP REQUIRED CONFIG PATHS )
 endif( )
 
 # Hip headers required of all clients; clients use hip to allocate
 # device memory
-find_package( hip REQUIRED CONFIG PATHS )
+find_package( HIP REQUIRED CONFIG PATHS )
 
 # CMake list of machine targets
 set( AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -69,8 +69,8 @@ endif( )
 # device memory.
 # NB: 2020-04-17: Using hip-clang compiled from source requires that
 # this not be added twice.
-if( NOT hip_FOUND)
-  find_package( hip REQUIRED CONFIG PATHS )
+if( NOT HIP_FOUND)
+  find_package( HIP REQUIRED CONFIG PATHS )
 endif()
 
 if( BUILD_CLIENTS_SAMPLES )

--- a/clients/samples/hipfft/CMakeLists.txt
+++ b/clients/samples/hipfft/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
-find_package(hip)
+find_package(HIP)
 
 if( NOT TARGET rocfft )
   find_package(rocfft)

--- a/clients/samples/rocfft/CMakeLists.txt
+++ b/clients/samples/rocfft/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
-find_package(hip)
+find_package(HIP)
 
 if( NOT TARGET rocfft )
   find_package(rocfft)

--- a/docs/samples/CMakeLists.txt
+++ b/docs/samples/CMakeLists.txt
@@ -37,7 +37,7 @@ foreach( exe ${samples} )
   target_include_directories( ${exe} PRIVATE ${rocfft_INCLUDE_DIR} )
   set_target_properties( ${exe} PROPERTIES CXX_STANDARD_REQUIRED ON)
   set_target_properties( ${exe} PROPERTIES CXX_STANDARD 14)
-  
+
   # prevent issue where __float128 is not supported
   set_target_properties( ${exe} PROPERTIES CXX_EXTENSIONS OFF)
 endforeach()

--- a/docs/samples/CMakeLists.txt
+++ b/docs/samples/CMakeLists.txt
@@ -25,7 +25,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 # project name
 PROJECT(rocfft_samples CXX)
 
-find_package(hip)
+find_package(HIP)
 find_package(rocfft)
 
 set (samples complex_1d complex_2d complex_3d real2complex_1d real2complex_2d real2complex_3d)

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -111,7 +111,7 @@ endif( )
 # Installation
 
 rocm_install_targets(
-  TARGETS ${package_targets} 
+  TARGETS ${package_targets}
   INCLUDE
   ${CMAKE_SOURCE_DIR}/library/include
   ${CMAKE_BINARY_DIR}/include

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -122,7 +122,7 @@ rocm_install_targets(
 rocm_export_targets(
   TARGETS roc::rocfft
   PREFIX rocfft
-  DEPENDS PACKAGE hip
+  DEPENDS PACKAGE HIP
   NAMESPACE roc::
   )
 


### PR DESCRIPTION
resolves #303 

Summary of proposed changes:
-  change find_package( hip ... calls to find_package( HIP ... to match the FindHIP.cmake file as installed by hip-base.
-  change export dep from hip to HIP
