### PR TITLE
fixes some bugs with incorrect calculation results

### DIFF
--- a/library/src/plan.cpp
+++ b/library/src/plan.cpp
@@ -2584,6 +2584,11 @@ void TreeNode::assign_buffers_CS_L1D_TRTRT(TraverseState&   state,
 
         size_t cs            = childNodes[1]->childNodes.size();
         childNodes[1]->obOut = childNodes[1]->childNodes[cs - 1]->obOut;
+
+		if(flipIn != obOutBuf)
+        {
+            std::swap(flipIn, flipOut);
+        }
     }
     else
     {
@@ -2904,6 +2909,9 @@ void TreeNode::TraverseTreeAssignPlacementsLogicA(const rocfft_array_type rootIn
                 break;
             case OB_TEMP:
                 inArrayType = rocfft_array_type_complex_interleaved;
+				if( childNodes.size()!=0 && parent->obIn==OB_TEMP_BLUESTEIN){
+					iOffset = parent->iOffset;
+				}
                 break;
             case OB_TEMP_CMPLX_FOR_REAL:
                 inArrayType = rocfft_array_type_complex_interleaved;
@@ -2936,6 +2944,9 @@ void TreeNode::TraverseTreeAssignPlacementsLogicA(const rocfft_array_type rootIn
                 break;
             case OB_TEMP:
                 outArrayType = rocfft_array_type_complex_interleaved;
+				if( childNodes.size()!=0 && parent->obOut==OB_TEMP_BLUESTEIN){
+					oOffset = parent->oOffset;
+				}
                 break;
             case OB_TEMP_CMPLX_FOR_REAL:
                 outArrayType = rocfft_array_type_complex_interleaved;
@@ -3487,7 +3498,8 @@ void TreeNode::assign_params_CS_L1D_TRTRT()
     auto& trans3Plan = childNodes[4];
 
     trans1Plan->inStride.push_back(inStride[0]);
-    trans1Plan->inStride.push_back(trans1Plan->length[0]);
+    // trans1Plan->inStride.push_back(trans1Plan->length[0]);
+    trans1Plan->inStride.push_back(inStride[0] * trans1Plan->length[0]);
     trans1Plan->iDist = iDist;
     for(size_t index = 1; index < length.size(); index++)
         trans1Plan->inStride.push_back(inStride[index]);

--- a/library/src/powX.cpp
+++ b/library/src/powX.cpp
@@ -148,6 +148,16 @@ bool PlanPowX(ExecPlan& execPlan)
             {
                 gp.b_x *= execPlan.execSeq[i]->length[2];
             }
+			if(execPlan.execSeq[i]->length.size() == 4)
+            {
+                gp.b_x *= execPlan.execSeq[i]->length[3] * execPlan.execSeq[i]->length[2] ;
+            }
+			if(execPlan.execSeq[i]->length.size() > 4)
+            {
+            	for(size_t j = 2; j < execPlan.execSeq[i]->length.size(); j++)
+                	gp.b_x *= execPlan.execSeq[i]->length[j] ;
+            }
+			
             gp.tpb_x = wgs;
             break;
         case CS_KERNEL_STOCKHAM_BLOCK_RC:
@@ -161,6 +171,15 @@ bool PlanPowX(ExecPlan& execPlan)
             if(execPlan.execSeq[i]->length.size() == 3)
             {
                 gp.b_x *= execPlan.execSeq[i]->length[2];
+            }
+			if(execPlan.execSeq[i]->length.size() == 4)
+            {
+                gp.b_x *= execPlan.execSeq[i]->length[3] * execPlan.execSeq[i]->length[2] ;
+            }
+			if(execPlan.execSeq[i]->length.size() > 4)
+            {
+            	for(size_t j = 2; j < execPlan.execSeq[i]->length.size(); j++)
+                	gp.b_x *= execPlan.execSeq[i]->length[j] ;
             }
             gp.tpb_x = wgs;
             break;


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
-  1.fixes incorrect calculation results of rocfft when the stride is not equal to 1;(modified 
      generator.kernel.hpp, transpose.h, plan.cpp )
-  2.fixes the incorrect calculation results of some large general length data of non radix-2, radix-3 
      and radix-5(eg:length=40353607,47045881);(modified plan.cpp  )
-  3.fixes the 2D-FFT's incorrect calculation results of some large 
      length(eg:lenx=32*1048576,leny=1); (modified powX.cpp)
-  4.fixes the 3D-FFT's incorrect calculation results of some large 
      length(eg:lenx=32*1048576,leny=1,lenz=1) (modified powX.cpp);

