### PR TITLE
transpose: implement large1D twiddle multiply for length < 256

### DIFF
--- a/clients/tests/accuracy_test.h
+++ b/clients/tests/accuracy_test.h
@@ -403,6 +403,7 @@ inline auto param_generator_base(const std::vector<rocfft_transform_type>&   typ
                                  const std::vector<std::vector<size_t>>&     v_lengths,
                                  const std::vector<rocfft_precision>&        precision_range,
                                  const std::vector<size_t>&                  batch_range,
+                                 decltype(generate_types)                    types_generator,
                                  const stride_generator&                     istride,
                                  const stride_generator&                     ostride,
                                  const std::vector<std::vector<size_t>>&     ioffset_range,
@@ -424,7 +425,7 @@ inline auto param_generator_base(const std::vector<rocfft_transform_type>&   typ
             {
                 for(const auto batch : batch_range)
                 {
-                    for(const auto& types : generate_types(transform_type, place_range))
+                    for(const auto& types : types_generator(transform_type, place_range))
                     {
                         for(const auto& istride_dist : istride.generate(lengths, batch))
                         {
@@ -485,6 +486,7 @@ inline auto param_generator(const std::vector<std::vector<size_t>>&     v_length
                                 v_lengths,
                                 precision_range,
                                 batch_range,
+                                generate_types,
                                 istride,
                                 ostride,
                                 ioffset_range,
@@ -507,6 +509,7 @@ inline auto param_generator_complex(const std::vector<std::vector<size_t>>&     
         v_lengths,
         precision_range,
         batch_range,
+        generate_types,
         istride,
         ostride,
         ioffset_range,
@@ -529,6 +532,7 @@ inline auto param_generator_real(const std::vector<std::vector<size_t>>&     v_l
         v_lengths,
         precision_range,
         batch_range,
+        generate_types,
         istride,
         ostride,
         ioffset_range,

--- a/library/src/device/kernels/transpose.h
+++ b/library/src/device/kernels/transpose.h
@@ -30,7 +30,18 @@
 #define TRANSPOSE_TWIDDLE_MUL(tmp)                                                                \
     if(WITH_TWL)                                                                                  \
     {                                                                                             \
-        if(TWL == 2)                                                                              \
+        if(TWL == 1)                                                                              \
+        {                                                                                         \
+            if(DIR == -1)                                                                         \
+            {                                                                                     \
+                TWIDDLE_STEP_MUL_FWD(TWLstep1, twiddles_large, (gx + tx1) * (gy + ty1 + i), tmp); \
+            }                                                                                     \
+            else                                                                                  \
+            {                                                                                     \
+                TWIDDLE_STEP_MUL_INV(TWLstep1, twiddles_large, (gx + tx1) * (gy + ty1 + i), tmp); \
+            }                                                                                     \
+        }                                                                                         \
+        else if(TWL == 2)                                                                         \
         {                                                                                         \
             if(DIR == -1)                                                                         \
             {                                                                                     \

--- a/library/src/device/transpose.cpp
+++ b/library/src/device/transpose.cpp
@@ -148,6 +148,77 @@ rocfft_status rocfft_transpose_outofplace_template(size_t      m,
             &HIP_KERNEL_NAME(
                 transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 0, 1, false, false, false>));
 
+        // twl=1:
+        tmap.emplace(
+            std::make_tuple(1, -1, true, true, true),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, -1, true, true, true>));
+        tmap.emplace(
+            std::make_tuple(1, -1, false, true, true),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, -1, false, true, true>));
+        tmap.emplace(
+            std::make_tuple(1, -1, true, false, true),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, -1, true, false, true>));
+        tmap.emplace(
+            std::make_tuple(1, -1, false, false, true),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, -1, false, false, true>));
+
+        tmap.emplace(
+            std::make_tuple(1, 1, true, true, true),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, 1, true, true, true>));
+        tmap.emplace(
+            std::make_tuple(1, 1, false, true, true),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, 1, false, true, true>));
+
+        tmap.emplace(
+            std::make_tuple(1, 1, true, false, true),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, 1, true, false, true>));
+        tmap.emplace(
+            std::make_tuple(1, 1, false, false, true),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, 1, false, false, true>));
+
+        tmap.emplace(
+            std::make_tuple(1, -1, true, true, false),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, -1, true, true, false>));
+        tmap.emplace(
+            std::make_tuple(1, -1, false, true, false),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, -1, false, true, false>));
+        tmap.emplace(
+            std::make_tuple(1, -1, true, false, false),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, -1, true, false, false>));
+        tmap.emplace(
+            std::make_tuple(1, -1, false, false, false),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, -1, false, false, false>));
+
+        tmap.emplace(
+            std::make_tuple(1, 1, true, true, false),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, 1, true, true, false>));
+        tmap.emplace(
+            std::make_tuple(1, 1, false, true, false),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, 1, false, true, false>));
+
+        tmap.emplace(
+            std::make_tuple(1, 1, true, false, false),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, 1, true, false, false>));
+        tmap.emplace(
+            std::make_tuple(1, 1, false, false, false),
+            &HIP_KERNEL_NAME(
+                transpose_kernel2<T, TA, TB, TRANSPOSE_DIM_X, TRANSPOSE_DIM_Y, true, 1, 1, false, false, false>));
+
         // twl=2:
         tmap.emplace(
             std::make_tuple(2, -1, true, true, true),
@@ -578,6 +649,8 @@ void rocfft_internal_transpose_var2(const void* data_p, void* back_p)
         twl = 3;
     else if(data->node->large1D > (size_t)256)
         twl = 2;
+    else if(data->node->large1D > 0)
+        twl = 1;
     else
         twl = 0;
 


### PR DESCRIPTION
* transpose: implement large1D twiddle multiply for length < 256

* rocfft-test: remove 1D prime sizes that are covered by radX

* rocfft-test: allow array type + placement to be overridden by test suites

* rocfft-test: test all 1D C2C sizes < 8k
