### PR TITLE
function pool: missing includes

### DIFF
--- a/library/src/include/function_pool.h
+++ b/library/src/include/function_pool.h
@@ -25,7 +25,11 @@
 
 #include "../device/kernels/common.h"
 #include "tree_node.h"
+#include <algorithm>
+#include <array>
+#include <utility>
 #include <unordered_map>
+#include <vector>
 
 using FMKey
     = std::tuple<std::array<size_t, 2>, rocfft_precision, ComputeScheme, SBRC_TRANSPOSE_TYPE>;


### PR DESCRIPTION
Fix missing includes and compile errors of the form:
```
rocFFT/library/src/device/generator/../../include/function_pool.h:143:31: error: no member named 'max_element' in namespace 'std'
        auto itr       = std::max_element(supported.cbegin(), supported.cend());
                         ~~~~~^
```

seen by @maxthevenet