### PR TITLE
Avoid increasing extra vpgrs for sbcc 64 inverse

### DIFF
--- a/library/src/device/stockham.py
+++ b/library/src/device/stockham.py
@@ -269,7 +269,13 @@ class StockhamLargeTwiddles2Step():
         stmts = StatementList()
         stmts += CommentLines('large twiddle multiplication')
         for w in range(width):
-            idx = B(B(thread % cumheight) + w * cumheight) * self.trans_local
+            # FIXME- using a .cast('type') would be graceful!
+            #        Why casting to ((int)thread % 8) only when passing to TW2step ?
+            #        This is completely based on the testing result. We observed that it can
+            #        reduce a few vgprs (we don't know why since its behind the compiler)
+            #        and avoid the drop of occuapancy (espcially for sbcc_len64_inverse)
+            # idx = B(B(thread % cumheight) + w * cumheight) * self.trans_local
+            idx = f'(((int){thread} % {cumheight}) + {w} * {cumheight}) * {self.trans_local}'
             stmts += Assign(W, InlineCall('TW2step',
                                           arguments=ArgumentList(self.large_twiddles, idx),
                                           templates=TemplateList(scalar_type, self.large_twiddle_base)))

--- a/library/src/node_factory.cpp
+++ b/library/src/node_factory.cpp
@@ -49,7 +49,7 @@ NodeFactory::Map1DLength const NodeFactory::map1DLengthSingle
 NodeFactory::Map1DLength const NodeFactory::map1DLengthDouble
     = {{4096, 64}, // pow of 2: CC (64cc + 64rc)
        {8192, 64}, //           CC (64cc + 128rc)
-       {16384, 128}, //         CC (128cc + 128rc) // faster than 64x256
+       {16384, 64}, //          CC (64cc + 256rc) // 128x128 ?
        {32768, 128}, //         CC (128cc + 256rc)
        {65536, 256}, //         CC (256cc + 256rc) // {65536, 64}
        {131072, 64}, //         CRT(64cc + 2048 + transpose)


### PR DESCRIPTION
resolves #SWDEV-287877

Fix: the 2 extra vgprs reduced the occupancy of sbcc 64 inverse from 2 to 1. Change data type from size_t back to int for sbcc.
Cherry-picked from develop branch
