### PR TITLE
fixed sbrc global load and added more adhoc tests

### DIFF
--- a/clients/tests/accuracy_test_adhoc.cpp
+++ b/clients/tests/accuracy_test_adhoc.cpp
@@ -32,6 +32,10 @@ std::vector<std::vector<size_t>> adhoc_sizes = {
 
     // L1D_CC subplan of 3D_TRTRTR
     {4, 4, 8192},
+
+    // SBRC 192 with special param
+    {192, 192, 192},
+    {192, 84, 84},
 };
 
 const static std::vector<std::vector<size_t>> stride_range = {{1}};


### PR DESCRIPTION
resolves [SWDEV-323016] incorrect results for 192x192x192 C2C
Cherry-pick for 5.1, as the release branch does not contain this work and it's necessary for 5.1.

This is a cherry-pick PR of https://github.com/ROCmSoftwarePlatform/rocFFT-internal/pull/710