### PR TITLE
changed sbcc81 back to radix-3 for Navi

### DIFF
--- a/library/src/device/kernel-generator.py
+++ b/library/src/device/kernel-generator.py
@@ -492,8 +492,7 @@ def list_large_kernels():
            'sp': 'true',  'dp': 'false'}),
         NS(length=80,  factors=[10, 8],      use_3steps_large_twd={
            'sp': 'false',  'dp': 'false'}),
-        # 9,9 is good when direct-to-reg
-        NS(length=81,  factors=[9, 9], use_3steps_large_twd={
+        NS(length=81,  factors=[3, 3, 3, 3], use_3steps_large_twd={
            'sp': 'true',  'dp': 'true'}, direct_to_reg=True),
         NS(length=84,  factors=[7, 2, 6],    use_3steps_large_twd={
            'sp': 'true',  'dp': 'true'}),


### PR DESCRIPTION
resolves #SWDEV-332069
The main cause is due to radix-9 is bad on navi
This PR will be re-targeted on rel-rocm-5.2 branch