### PR TITLE
changed sbcc81 back to radix-3 for Navi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Full documentation for rocFFT is available at [rocfft.readthedocs.io](https://ro
 
 ### Optimizations
 - Introduced a new access pattern of lds (non-linear) and applied it on
-  sbcc kernels len 64 and 81 to get performance improvement.
+  sbcc kernels len 64 to get performance improvement.
 
 ## rocFFT 1.0.16  for ROCm 5.1.0
 
@@ -24,7 +24,7 @@ Full documentation for rocFFT is available at [rocfft.readthedocs.io](https://ro
 - Enabled runtime compilation of length-2304 FFT kernel during plan creation.
 - Added tokenizer for test suite.
 - Reduce twiddle memory requirements for even-length real-complex transforms.
-- Clients can now be built separately from the main library.  
+- Clients can now be built separately from the main library.
 
 ### Optimizations
 - Optimized more large 1D cases by using L1D_CC plan.

--- a/library/src/device/kernel-generator.py
+++ b/library/src/device/kernel-generator.py
@@ -492,9 +492,9 @@ def list_large_kernels():
            'sp': 'true',  'dp': 'false'}),
         NS(length=80,  factors=[10, 8],      use_3steps_large_twd={
            'sp': 'false',  'dp': 'false'}),
-        # 9,9 is good when direct-to-reg
-        NS(length=81,  factors=[9, 9], use_3steps_large_twd={
-           'sp': 'true',  'dp': 'true'}, direct_to_reg=True),
+        # [9,9] with direct_to_reg is good except for Navi, so disable it for now
+        NS(length=81,  factors=[3, 3, 3, 3], use_3steps_large_twd={
+           'sp': 'true',  'dp': 'true'}),
         NS(length=84,  factors=[7, 2, 6],    use_3steps_large_twd={
            'sp': 'true',  'dp': 'true'}),
         NS(length=96,  factors=[8, 3, 4],    use_3steps_large_twd={


### PR DESCRIPTION
resolves #SWDEV-332069 
The main cause is due to radix-9 is bad on Navi, so we disable the new experiment feature on sbcc81 on 5.2 to avoid the regression. 
Since ROCm 5.3 will re-enable it with better support. So this PR is picked to rocm-5.2 branch