### PR TITLE
don't use sbcc 243 on 243^3

### DIFF
--- a/library/src/node_factory.cpp
+++ b/library/src/node_factory.cpp
@@ -607,6 +607,13 @@ ComputeScheme NodeFactory::Decide3DScheme(NodeMetaData& nodeData)
             return CS_3D_TRTRTR;
         }
 
+        // a workaround to disable sbcc-243 on gfx90a when 243^3
+        if(childScheme == CS_2D_RC && nodeData.length[1] == 243
+           && is_device_gcn_arch(nodeData.deviceProp, "gfx90a"))
+        {
+            return CS_3D_TRTRTR;
+        }
+
         return CS_3D_RTRT;
     }
     // TODO: CS_KERNEL_3D_SINGLE?


### PR DESCRIPTION
resolves #SWDEV-333618
This is a workaround for 5.2 only, 5.3 will not have this issue.