### PR TITLE
ENABLE ORIGINAL FILE DUMP IN VERSION HDR FILE WRAPPER FOR BKWDCOMP

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -250,6 +250,7 @@ if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
     rocfft-version.h rocfft-export.h
     GUARDS SYMLINK WRAPPER
     WRAPPER_LOCATIONS include rocfft/include
+    ORIGINAL_FILES ${PROJECT_BINARY_DIR}/include/rocfft/rocfft-version.h
   )
 endif( )
 


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
- Original Header File Dump enabled for version header file wrapper to support backward Compatibility for PT/TF
- Depends on wrapper functions of rocm-cmake version https://github.com/RadeonOpenCompute/rocm-cmake/commit/d108dbf05e029996d5d7bcbe258abb1166547a30
