### PR TITLE
Add gfx1101 to default AMDGPU_TARGETS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Full documentation for rocFFT is available at [rocfft.readthedocs.io](https://ro
 ### Added
 - Added rocfft_plan_description_set_scale_factor API to efficiently multiply each output element of a FFT by a given scaling factor.
 - Created a rocfft_kernel_cache.db file next to the installed library. SBCC kernels are moved to this file when built with the library, and are runtime-compiled for new GPU architectures.
-- Added gfx1100 and gfx1102 to default AMDGPU_TARGETS.
+- Added gfx1100, gfx1101, and gfx1102 to default AMDGPU_TARGETS.
 
 ### Changed
 - Moved runtime compilation cache to in-memory by default.  A default on-disk cache can encounter contention problems 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ endif( )
 
 # Use target ID syntax if supported for AMDGPU_TARGETS
 rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-  TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx1030;gfx1100;gfx1102")
+  TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx1030;gfx1100;gfx1101;gfx1102")
 set(AMDGPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
 list(LENGTH AMDGPU_TARGETS AMDGPU_TARGETS_LENGTH)
 


### PR DESCRIPTION
Summary of proposed changes:
-  Adds gfx1101 (Navi 32) to default AMDGPU_TARGETS