### PR TITLE
Correct hip path for new directory layout

### DIFF
--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -21,9 +21,9 @@
 # #############################################################################
 
 if (DEFINED ENV{ROCM_PATH})
-  set(rocm_bin "$ENV{ROCM_PATH}/hip/bin")
+  set(rocm_bin "$ENV{ROCM_PATH}/bin")
 else()
-  set(rocm_bin "/opt/rocm/hip/bin")
+  set(rocm_bin "/opt/rocm/bin")
 endif()
 
 set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc")


### PR DESCRIPTION
SWDEV-345870 - Use actual hip installation path /opt/rocm-ver rather than using backward compatibility path /opt/rocm-ver/hip

resolves #___

Summary of proposed changes:
-  
-  
-  
