### PR TITLE
HOTFIX: Remove extra header location from install call

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -380,7 +380,6 @@ endif( )
 rocm_install_targets(
   TARGETS ${package_targets}
   INCLUDE
-  ${CMAKE_SOURCE_DIR}/library/include
   ${CMAKE_BINARY_DIR}/include
   )
 
@@ -411,4 +410,3 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
         DESTINATION "." )
   message( STATUS "Backward Compatible Sym Link Created for include directories" )
 endif()
-


### PR DESCRIPTION
resolves SWDEV-362068

Summary of proposed changes:

- Remove source directory from rocm_install_targets call to prevent installation of rocfft.h in an unintended location