### PR TITLE
cmake: restore gfx803, gfx900 for clients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ endif( )
 
 # Use target ID syntax if supported for AMDGPU_TARGETS
 rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-  TARGETS "gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx1030;gfx1100;gfx1101;gfx1102")
+  TARGETS "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx1030;gfx1100;gfx1101;gfx1102")
 set(AMDGPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
 list(LENGTH AMDGPU_TARGETS AMDGPU_TARGETS_LENGTH)
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -391,9 +391,16 @@ endif()
 # to collect compiled kernels before writing them out as part of the
 # build.  any kernels that already exist in this file will be reused
 # between builds.
+
+# Only build kernels ahead-of-time for a more limited set of
+# architectures.  Less common architectures are filtered out from the
+# list and kernels for them are built at runtime instead.
+set( AMDGPU_TARGETS_AOT ${AMDGPU_TARGETS} )
+list( REMOVE_ITEM AMDGPU_TARGETS_AOT gfx803 )
+list( REMOVE_ITEM AMDGPU_TARGETS_AOT gfx900 )
 add_custom_command(
   OUTPUT rocfft_kernel_cache.db
-  COMMAND rocfft_aot_helper \"${ROCFFT_BUILD_KERNEL_CACHE_PATH}\" ${ROCFFT_KERNEL_CACHE_PATH} $<TARGET_FILE:rocfft_rtc_helper> ${AMDGPU_TARGETS}
+  COMMAND rocfft_aot_helper \"${ROCFFT_BUILD_KERNEL_CACHE_PATH}\" ${ROCFFT_KERNEL_CACHE_PATH} $<TARGET_FILE:rocfft_rtc_helper> ${AMDGPU_TARGETS_AOT}
   DEPENDS rocfft_aot_helper rocfft_rtc_helper
   COMMENT "Compile kernels into shipped cache file"
 )


### PR DESCRIPTION
Picks d53015575c8615d80797934451c54f2b30bf0461 from develop for ROCm 5.5.
