### PR TITLE
remove extra header location from install call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for rocFFT is available at [rocfft.readthedocs.io](https://rocfft.readthedocs.io/en/latest/).
 
-## rocFFT 1.0.21 for ROCm 5.5.0
+## rocFFT 1.0.22 for ROCm 5.5.0
 
 ### Optimizations
 - Improved performance of 1D lengths < 2048 that use Bluestein's algorithm.
@@ -21,6 +21,11 @@ Full documentation for rocFFT is available at [rocfft.readthedocs.io](https://ro
 ### Fixed
 - Removed zero-length twiddle table allocations, which fixes errors from hipMallocManaged.
 - Fixed incorrect freeing of HIP stream handles during twiddle computation when multiple devices are present.
+
+## rocFFT 1.0.21 for ROCm 5.4.3
+
+### Fixed
+- Removed source directory from rocm_install_targets call to prevent installation of rocfft.h in an unintended location.
 
 ## rocFFT 1.0.20 for ROCm 5.4.1
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -430,7 +430,6 @@ endif( )
 rocm_install_targets(
   TARGETS ${package_targets}
   INCLUDE
-  ${CMAKE_SOURCE_DIR}/library/include
   ${CMAKE_BINARY_DIR}/include
   )
 
@@ -461,4 +460,3 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
         DESTINATION "." )
   message( STATUS "Backward Compatible Sym Link Created for include directories" )
 endif()
-


### PR DESCRIPTION
* bump version to 1.0.21 for ROCm 5.4.3

Co-authored-by: Steve Leung <Steve.Leung@amd.com>
