### PR TITLE
cmake: don't set HIP_PLATFORM, HIP_COMPILER, USE_HIP_CLANG 

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -20,7 +20,6 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean b
     String buildTypeArg = debug ? '-DCMAKE_BUILD_TYPE=Debug -DROCFFT_DEVICE_FORCE_RELEASE=ON' : '-DCMAKE_BUILD_TYPE=Release'
     String buildTypeDir = debug ? 'debug' : 'release'
     String staticArg = buildStatic ? '-DBUILD_SHARED_LIBS=off' : ''
-    String hipClangArgs = jobName.contains('hipclang') ? '-DUSE_HIP_CLANG=ON -DHIP_COMPILER=clang' : ''
     String cmake = platform.jenkinsLabel.contains('centos') ? 'cmake3' : 'cmake'
     //Set CI node's gfx arch as target if PR, otherwise use default targets of the library
     String amdgpuTargets = env.BRANCH_NAME.startsWith('PR-') ? '-DAMDGPU_TARGETS=\$gfx_arch' : ''
@@ -33,7 +32,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean b
                 set -e
                 mkdir -p build/${buildTypeDir} && cd build/${buildTypeDir}
                 ${auxiliary.gfxTargetParser()}
-                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc ${buildTypeArg} ${clientArgs} ${warningArgs} ${buildTunerArgs} ${hipClangArgs} ${staticArg} ${amdgpuTargets} ${rtcBuildCache} ../..
+                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc ${buildTypeArg} ${clientArgs} ${warningArgs} ${buildTunerArgs} ${staticArg} ${amdgpuTargets} ${rtcBuildCache} ../..
                 make -j\$(nproc)
                 sudo make install
             """
@@ -52,7 +51,6 @@ def runCompileClientCommand(platform, project, jobName, boolean debug=false)
     String buildTypeArg = debug ? '-DCMAKE_BUILD_TYPE=Debug -DROCFFT_DEVICE_FORCE_RELEASE=ON' : '-DCMAKE_BUILD_TYPE=Release'
     String buildTypeDir = debug ? 'debug' : 'release'
     //String staticArg = buildStatic ? '-DBUILD_SHARED_LIBS=off' : ''
-    String hipClangArgs = jobName.contains('hipclang') ? '-DUSE_HIP_CLANG=ON -DHIP_COMPILER=clang' : ''
     String cmake = platform.jenkinsLabel.contains('centos') ? 'cmake3' : 'cmake'
     String amdgpuTargets = env.BRANCH_NAME.startsWith('PR-') ? '-DAMDGPU_TARGETS=\$gfx_arch' : ''
 
@@ -63,7 +61,7 @@ def runCompileClientCommand(platform, project, jobName, boolean debug=false)
                 set -ex
                 cd ${project.paths.project_build_prefix}/clients
                 mkdir -p build && cd build
-                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc ${buildTypeArgClients} ${hipClangArgs} ${cmakePrefixPathArg} ../
+                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc ${buildTypeArgClients} ${cmakePrefixPathArg} ../
                 make -j\$(nproc)
             """
     platform.runCommand(this, command)
@@ -116,7 +114,6 @@ def runSubsetBuildCommand(platform, project, jobName, genPattern, genSmall, genL
     String precisionArgs = onlyDouble ? '-DGENERATOR_PRECISION=double' : ''
     String kernelArgs = "${genPatternArgs} ${manualSmallArgs} ${manualLargeArgs} ${precisionArgs}"
 
-    String hipClangArgs = jobName.contains('hipclang') ? '-DUSE_HIP_CLANG=ON -DHIP_COMPILER=clang' : ''
     String cmake = platform.jenkinsLabel.contains('centos') ? 'cmake3' : 'cmake'
     //Set CI node's gfx arch as target if PR, otherwise use default targets of the library
     String amdgpuTargets = env.BRANCH_NAME.startsWith('PR-') ? '-DAMDGPU_TARGETS=\$gfx_arch' : ''
@@ -129,7 +126,7 @@ def runSubsetBuildCommand(platform, project, jobName, genPattern, genSmall, genL
                 rm -rf build/${buildTypeDir}
                 mkdir -p build/${buildTypeDir} && cd build/${buildTypeDir}
                 ${auxiliary.gfxTargetParser()}
-                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc ${buildTypeArg} ${clientArgs} ${kernelArgs} ${warningArgs} ${hipClangArgs} ${amdgpuTargets} ${rtcBuildCache} ../..
+                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc ${buildTypeArg} ${clientArgs} ${kernelArgs} ${warningArgs} ${amdgpuTargets} ${rtcBuildCache} ../..
                 make -j\$(nproc)
             """
     platform.runCommand(this, command)

--- a/.jenkins/performance.groovy
+++ b/.jenkins/performance.groovy
@@ -33,7 +33,6 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean b
     String warningArgs = '-DWERROR=ON'
     String buildTypeArg = debug ? '-DCMAKE_BUILD_TYPE=Debug -DROCFFT_DEVICE_FORCE_RELEASE=ON' : '-DCMAKE_BUILD_TYPE=Release'
     String buildTypeDir = debug ? 'debug' : 'release'
-    String hipClangArgs = jobName.contains('hipclang') ? '-DUSE_HIP_CLANG=ON -DHIP_COMPILER=clang' : ''
     String rtcBuildCache = "-DROCFFT_BUILD_KERNEL_CACHE_PATH=\$JENKINS_HOME_DIR/rocfft_build_cache.db"
     String cmake = platform.jenkinsLabel.contains('centos') ? 'cmake3' : 'cmake'
 
@@ -44,13 +43,13 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean b
                 set -e
                 mkdir -p build/${buildTypeDir} && pushd build/${buildTypeDir}
                 ${auxiliary.gfxTargetParser()}
-                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc -DAMDGPU_TARGETS=\$gfx_arch -DSINGLELIB=on ${buildTypeArg} ${clientArgs} ${warningArgs} ${hipClangArgs} ${rtcBuildCache} ../..
+                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc -DAMDGPU_TARGETS=\$gfx_arch -DSINGLELIB=on ${buildTypeArg} ${clientArgs} ${warningArgs} ${rtcBuildCache} ../..
                 make -j\$(nproc)
                 popd
                 cd ref-repo
                 mkdir -p build/${buildTypeDir} && pushd build/${buildTypeDir}
                 ${auxiliary.gfxTargetParser()}
-                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc -DAMDGPU_TARGETS=\$gfx_arch -DSINGLELIB=on ${buildTypeArg} ${noclientArgs} ${warningArgs} ${hipClangArgs} ${rtcBuildCache} ../..
+                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc -DAMDGPU_TARGETS=\$gfx_arch -DSINGLELIB=on ${buildTypeArg} ${noclientArgs} ${warningArgs} ${rtcBuildCache} ../..
                 make -j\$(nproc)
             """
     platform.runCommand(this, command)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,16 +49,6 @@ set( ROCFFT_BUILD_SCOPE ON )
 
 project( rocfft LANGUAGES CXX C )
 
-# Control hip-clang use:
-set( USE_HIP_CLANG OFF CACHE BOOL "Use hip-clang to build for amdgpu" )
-if( USE_HIP_CLANG )
-  message( STATUS "Use hip-clang to build for amdgpu backend" )
-  set( HIP_PLATFORM "hip-clang" )
-  set( HIP_COMPILER "clang" )
-else()
-  set( HIP_PLATFORM "hcc" )
-endif()
-
 # This finds the rocm-cmake project, and installs it if not found
 # rocm-cmake contains common cmake code for rocm projects to help setup and install
 set( PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern )

--- a/README.md
+++ b/README.md
@@ -34,12 +34,11 @@ make -j
 
 A static library can be compiled by using the option `-DBUILD_SHARED_LIBS=off`
 
-To use the [hip-clang compiler][3], one must specify
-`-DUSE_HIP_CLANG=ON -DHIP_COMPILER=clang` to cmake.  rocFFT enables
-use of indirect function calls by default and requires ROCm 4.3 or
-higher to build successfully.  `-DROCFFT_CALLBACKS_ENABLED=off`
-may be specified to cmake to disable those calls on older ROCm
-compilers, though callbacks will not work correctly in this configuration.
+rocFFT enables use of indirect function calls by default and requires
+ROCm 4.3 or higher to build successfully.
+`-DROCFFT_CALLBACKS_ENABLED=off` may be specified to cmake to disable
+those calls on older ROCm compilers, though callbacks will not work
+correctly in this configuration.
 
 There are several clients included with rocFFT:
 1. rocfft-rider runs general transforms and is useful for performance analysis;

--- a/install.sh
+++ b/install.sh
@@ -273,7 +273,6 @@ build_clients=false
 build_release=true
 build_tuner=false
 build_relocatable=false
-build_hip_clang=true
 pattern_arg=false
 precision_arg=false
 group_num=false
@@ -326,9 +325,6 @@ while true; do
             shift ;;
         -t|--tuner)
             build_tuner=true
-            shift ;;
-        --hip-clang)
-            build_hip_clang=true
             shift ;;
         --address-sanitizer)
             build_address_sanitizer=true
@@ -492,13 +488,6 @@ if [[ "${build_clients}" == true ]]; then
 fi
 
 compiler="hipcc"
-if [[ "${build_hip_clang}" == true ]]; then
-    compiler="hipcc"
-fi
-
-if [[ "${build_hip_clang}" == true ]]; then
-    cmake_common_options="${cmake_common_options} -DUSE_HIP_CLANG=ON -DHIP_COMPILER=clang"
-fi
 
 # Build library with AMD toolchain because of existense of device kernels
 if [[ "${build_clients}" == false ]]; then


### PR DESCRIPTION
HIP_PLATFORM needs to be set by users (assuming it's even necessary), not
by rocFFT.  We can just use defaults for the others.