### PR TITLE
Silence python invalid escape warning

### DIFF
--- a/library/src/device/kernel-generator-embed-cpp.py
+++ b/library/src/device/kernel-generator-embed-cpp.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
     # regex to filter out #include statements, since those can't work
     # for RTC.  The runtime ensures that all the really important
     # includes are already done for us.
-    include_regex = re.compile('''^\s*#include''')
+    include_regex = re.compile(r'''^\s*#include''')
 
     # embed files as strings
     outfile.write("#include <array>\n")


### PR DESCRIPTION
On Fedora/rawhide with Python 3.12.0b4
There is this warning
rocFFT/library/src/device/kernel-generator-embed-cpp.py:63: SyntaxWarning: invalid escape sequence '\s'
  include_regex = re.compile('''^\s*#include''')

Change to a raw string

