### PR TITLE
SWDEV-428379 - Set LD_LIBRARY_PATH for executing the binaries from build directory

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -517,9 +517,11 @@ endif()
 set( AMDGPU_TARGETS_AOT ${AMDGPU_TARGETS} )
 list( REMOVE_ITEM AMDGPU_TARGETS_AOT gfx803 )
 list( REMOVE_ITEM AMDGPU_TARGETS_AOT gfx900 )
+# The binary will be having relative RUNPATH with respect to install directory
+# Set LD_LIBRARY_PATH for executing the binary from build directory.
 add_custom_command(
   OUTPUT rocfft_kernel_cache.db
-  COMMAND rocfft_aot_helper \"${ROCFFT_BUILD_KERNEL_CACHE_PATH}\" ${ROCFFT_KERNEL_CACHE_PATH} $<TARGET_FILE:rocfft_rtc_helper> ${AMDGPU_TARGETS_AOT}
+  COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${ROCM_PATH}/${CMAKE_INSTALL_LIBDIR}" ./rocfft_aot_helper \"${ROCFFT_BUILD_KERNEL_CACHE_PATH}\" ${ROCFFT_KERNEL_CACHE_PATH} $<TARGET_FILE:rocfft_rtc_helper> ${AMDGPU_TARGETS_AOT}
   DEPENDS rocfft_aot_helper rocfft_rtc_helper
   COMMENT "Compile default kernels and solution-map kernels into shipped cache file"
 )

--- a/library/src/device/CMakeLists.txt
+++ b/library/src/device/CMakeLists.txt
@@ -112,8 +112,10 @@ if( STATUS AND NOT STATUS EQUAL 0 )
   message( FATAL_ERROR "Kernel generator failed (list): ${STATUS}")
 endif()
 
+# stockham_aot will be having relative RUNPATH with respect to package install directory
+# Set LD_LIBRARY_PATH for running the executable from build directory
 add_custom_command(OUTPUT ${gen_headers}
-  COMMAND ${PYTHON3_EXE} ${kgen}
+  COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${ROCM_PATH}/${CMAKE_INSTALL_LIBDIR}" ${PYTHON3_EXE} ${kgen}
   --pattern=${GENERATOR_PATTERN}
   --precision=${GENERATOR_PRECISION}
   --manual-small=${GENERATOR_MANUAL_SMALL_SIZE}


### PR DESCRIPTION
The binaries rocfft_aot_helper and stockham_aot are getting executed from build directory during build time. The hardcoded RUNPATH in this binaries are helping to find the required libraries. Hardcoded RUNPATH will be removed and will be having relative RUNPATH with respect to install directory. LD_LIBRARY_PATH need to set during build time for a successfull exectuion of the binaries

resolves #___

Summary of proposed changes:
-  
-  
-  
