### PR TITLE
cmake: set clients to depend on "boost" on mariner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,8 @@ if( BUILD_CLIENTS_SAMPLES
   endif()
   if(CLIENTS_OS STREQUAL "sles")
     set(BOOST_RPM RPM "libboost_program_options${Boost_VERSION_MAJOR}_${Boost_VERSION_MINOR}_${Boost_VERSION_PATCH}")
+  elseif(CLIENTS_OS STREQUAL "mariner")
+    set(BOOST_RPM RPM "boost = ${Boost_VERSION_MAJOR}_${Boost_VERSION_MINOR}_${Boost_VERSION_PATCH}")
   endif()
   rocm_package_setup_component(clients)
   if(BUILD_CLIENTS_TESTS)


### PR DESCRIPTION
Mariner only has a single boost package that includes everything.

6.2 cherry-pick for https://ontrack-internal.amd.com/browse/SWDEV-466045.