### PR TITLE
Fix GTest skip/fail propagation throughout bitwise repro tests

### DIFF
--- a/clients/tests/bitwise_repro/bitwise_repro_test.cpp
+++ b/clients/tests/bitwise_repro/bitwise_repro_test.cpp
@@ -51,7 +51,18 @@ TEST(bitwise_repro_test, compare_precisions)
         GTEST_SKIP();
     }
 
-    bitwise_repro(params_1, params_2);
+    try
+    {
+        bitwise_repro(params_1, params_2);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
     SUCCEED();
 }
 
@@ -75,7 +86,18 @@ TEST(bitwise_repro_test, compare_lengths)
         GTEST_SKIP();
     }
 
-    bitwise_repro(params_1, params_2);
+    try
+    {
+        bitwise_repro(params_1, params_2);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
     SUCCEED();
 }
 
@@ -99,7 +121,18 @@ TEST(bitwise_repro_test, compare_transform_types)
         GTEST_SKIP();
     }
 
-    bitwise_repro(params_1, params_2);
+    try
+    {
+        bitwise_repro(params_1, params_2);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
     SUCCEED();
 }
 
@@ -128,7 +161,18 @@ TEST_P(bitwise_repro_test, compare_to_reference)
         GTEST_SKIP();
     }
 
-    bitwise_repro(params);
+    try
+    {
+        bitwise_repro(params);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
     SUCCEED();
 }
 

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -591,5 +591,17 @@ TEST(manual, bitwise_reproducibility) // MANUAL TESTS HERE
         std::cout << "manual params are not valid\n";
     }
 
-    bitwise_repro(params);
+    try
+    {
+        bitwise_repro(params);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
+    SUCCEED();
 }


### PR DESCRIPTION
6.2 cherry pick for https://ontrack-internal.amd.com/browse/SWDEV-465970.

Cherry picked commit: e8231050db7a49e356252e496376a10fa532fecb
