### PR TITLE
Fix GTest skip/fail propagation throughout bitwise repro tests

### DIFF
--- a/clients/tests/accuracy_test_1D.cpp
+++ b/clients/tests/accuracy_test_1D.cpp
@@ -25,9 +25,9 @@
 
 #include "../../shared/accuracy_test.h"
 #include "../../shared/fftw_transform.h"
+#include "../../shared/params_gen.h"
 #include "../../shared/rocfft_against_fftw.h"
 #include "accuracy_tests_range.h"
-#include "params_gen.h"
 
 using ::testing::ValuesIn;
 

--- a/clients/tests/accuracy_test_2D.cpp
+++ b/clients/tests/accuracy_test_2D.cpp
@@ -25,9 +25,9 @@
 
 #include "../../shared/accuracy_test.h"
 #include "../../shared/fftw_transform.h"
+#include "../../shared/params_gen.h"
 #include "../../shared/rocfft_against_fftw.h"
 #include "accuracy_tests_range.h"
-#include "params_gen.h"
 
 using ::testing::ValuesIn;
 

--- a/clients/tests/accuracy_test_3D.cpp
+++ b/clients/tests/accuracy_test_3D.cpp
@@ -25,9 +25,9 @@
 
 #include "../../shared/accuracy_test.h"
 #include "../../shared/fftw_transform.h"
+#include "../../shared/params_gen.h"
 #include "../../shared/rocfft_against_fftw.h"
 #include "accuracy_tests_range.h"
-#include "params_gen.h"
 
 using ::testing::ValuesIn;
 

--- a/clients/tests/accuracy_test_adhoc.cpp
+++ b/clients/tests/accuracy_test_adhoc.cpp
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 
 #include "../../shared/accuracy_test.h"
-#include "params_gen.h"
+#include "../../shared/params_gen.h"
 
 std::vector<std::vector<size_t>> adhoc_sizes = {
     // sizes that exercise L1D_TRTRT subplan of 2D_RTRT or 3D_TRTRTR

--- a/clients/tests/accuracy_test_callback.cpp
+++ b/clients/tests/accuracy_test_callback.cpp
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 #include "../../shared/accuracy_test.h"
-#include "params_gen.h"
+#include "../../shared/params_gen.h"
 
 std::vector<std::vector<size_t>> callback_sizes = {
     // some single kernel sizes

--- a/clients/tests/accuracy_test_checkstride.cpp
+++ b/clients/tests/accuracy_test_checkstride.cpp
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 #include "../../shared/accuracy_test.h"
-#include "params_gen.h"
+#include "../../shared/params_gen.h"
 
 extern bool fftw_compare;
 

--- a/clients/tests/bitwise_repro/bitwise_repro_test.cpp
+++ b/clients/tests/bitwise_repro/bitwise_repro_test.cpp
@@ -51,7 +51,18 @@ TEST(bitwise_repro_test, compare_precisions)
         GTEST_SKIP();
     }
 
-    bitwise_repro(params_1, params_2);
+    try
+    {
+        bitwise_repro(params_1, params_2);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
     SUCCEED();
 }
 
@@ -75,7 +86,18 @@ TEST(bitwise_repro_test, compare_lengths)
         GTEST_SKIP();
     }
 
-    bitwise_repro(params_1, params_2);
+    try
+    {
+        bitwise_repro(params_1, params_2);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
     SUCCEED();
 }
 
@@ -99,7 +121,18 @@ TEST(bitwise_repro_test, compare_transform_types)
         GTEST_SKIP();
     }
 
-    bitwise_repro(params_1, params_2);
+    try
+    {
+        bitwise_repro(params_1, params_2);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
     SUCCEED();
 }
 
@@ -128,7 +161,18 @@ TEST_P(bitwise_repro_test, compare_to_reference)
         GTEST_SKIP();
     }
 
-    bitwise_repro(params);
+    try
+    {
+        bitwise_repro(params);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
     SUCCEED();
 }
 

--- a/clients/tests/bitwise_repro/bitwise_repro_test.cpp
+++ b/clients/tests/bitwise_repro/bitwise_repro_test.cpp
@@ -23,9 +23,9 @@
 #include <stdexcept>
 #include <vector>
 
+#include "../../../shared/params_gen.h"
 #include "../../../shared/rocfft_params.h"
 #include "../accuracy_tests_range.h"
-#include "../params_gen.h"
 #include "bitwise_repro_test.h"
 
 using ::testing::ValuesIn;

--- a/clients/tests/callback_change_type.cpp
+++ b/clients/tests/callback_change_type.cpp
@@ -19,9 +19,9 @@
 // THE SOFTWARE.
 
 #include "../../shared/hostbuf.h"
+#include "../../shared/params_gen.h"
 #include "../../shared/rocfft_complex.h"
 #include "../../shared/rocfft_params.h"
-#include "params_gen.h"
 
 #include "../../shared/accuracy_test.h"
 #include "../../shared/fftw_transform.h"

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -602,5 +602,17 @@ TEST(manual, bitwise_reproducibility) // MANUAL TESTS HERE
         std::cout << "manual params are not valid\n";
     }
 
-    bitwise_repro(params);
+    try
+    {
+        bitwise_repro(params);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
+    SUCCEED();
 }

--- a/clients/tests/gtest_main.cpp
+++ b/clients/tests/gtest_main.cpp
@@ -568,7 +568,18 @@ TEST(manual, vs_fftw) // MANUAL TESTS HERE
         std::cout << "manual params are not valid\n";
     }
 
-    fft_vs_reference(params);
+    try
+    {
+        fft_vs_reference(params);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
 }
 
 TEST(manual, bitwise_reproducibility) // MANUAL TESTS HERE

--- a/clients/tests/multi_device_test.cpp
+++ b/clients/tests/multi_device_test.cpp
@@ -19,8 +19,8 @@
 // THE SOFTWARE.
 
 #include "../../shared/accuracy_test.h"
+#include "../../shared/params_gen.h"
 #include "../../shared/rocfft_params.h"
-#include "params_gen.h"
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
 

--- a/clients/tests/random.cpp
+++ b/clients/tests/random.cpp
@@ -23,9 +23,9 @@
 #include <random>
 
 #include "../../shared/accuracy_test.h"
+#include "../../shared/params_gen.h"
 #include "../../shared/rocfft_accuracy_test.h"
 #include "../../shared/test_params.h"
-#include "params_gen.h"
 
 class random_params
     : public ::testing::TestWithParam<

--- a/clients/tests/rocfft_accuracy_test.cpp
+++ b/clients/tests/rocfft_accuracy_test.cpp
@@ -29,6 +29,7 @@
 
 #include "../../shared/fftw_transform.h"
 #include "../../shared/gpubuf.h"
+#include "../../shared/gtest_except.h"
 #include "../../shared/rocfft_against_fftw.h"
 #include "rocfft/rocfft.h"
 
@@ -74,6 +75,17 @@ TEST_P(accuracy_test, vs_fftw)
     // only do round trip for non-field FFTs
     bool round_trip = params.ifields.empty() && params.ofields.empty();
 
-    fft_vs_reference(params, round_trip);
+    try
+    {
+        fft_vs_reference(params, round_trip);
+    }
+    catch(ROCFFT_GTEST_SKIP& e)
+    {
+        GTEST_SKIP() << e.msg.str();
+    }
+    catch(ROCFFT_GTEST_FAIL& e)
+    {
+        GTEST_FAIL() << e.msg.str();
+    }
     SUCCEED();
 }

--- a/shared/accuracy_test.h
+++ b/shared/accuracy_test.h
@@ -401,11 +401,11 @@ inline void execute_gpu_fft(Tparams&              params,
             ++n_hip_failures;
             if(skip_runtime_fails)
             {
-                throw ROCFFT_GTEST_SKIP{};
+                throw ROCFFT_GTEST_SKIP();
             }
             else
             {
-                throw ROCFFT_GTEST_FAIL{};
+                throw ROCFFT_GTEST_FAIL();
             }
         }
         hip_status = hipMemcpy(load_cb_data_dev.data(),
@@ -417,11 +417,11 @@ inline void execute_gpu_fft(Tparams&              params,
             ++n_hip_failures;
             if(skip_runtime_fails)
             {
-                throw ROCFFT_GTEST_SKIP{};
+                throw ROCFFT_GTEST_SKIP();
             }
             else
             {
-                throw ROCFFT_GTEST_FAIL{};
+                throw ROCFFT_GTEST_FAIL();
             }
         }
 
@@ -447,11 +447,11 @@ inline void execute_gpu_fft(Tparams&              params,
             ++n_hip_failures;
             if(skip_runtime_fails)
             {
-                throw ROCFFT_GTEST_SKIP{};
+                throw ROCFFT_GTEST_SKIP();
             }
             else
             {
-                throw ROCFFT_GTEST_FAIL{};
+                throw ROCFFT_GTEST_FAIL();
             }
         }
 
@@ -464,11 +464,11 @@ inline void execute_gpu_fft(Tparams&              params,
             ++n_hip_failures;
             if(skip_runtime_fails)
             {
-                throw ROCFFT_GTEST_SKIP{};
+                throw ROCFFT_GTEST_SKIP();
             }
             else
             {
-                throw ROCFFT_GTEST_FAIL{};
+                throw ROCFFT_GTEST_FAIL();
             }
         }
 
@@ -1092,7 +1092,7 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
                 std::cout << "Problem exceeds memory limit; skipped [rocfft_transform]."
                           << std::endl;
             }
-            throw ROCFFT_GTEST_SKIP{};
+            throw ROCFFT_GTEST_SKIP();
         }
     }
 

--- a/shared/gtest_except.h
+++ b/shared/gtest_except.h
@@ -1,0 +1,38 @@
+// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ROCFFT_GTEST_EXCEPT_H
+#define ROCFFT_GTEST_EXCEPT_H
+
+#include <sstream>
+
+// exception type to throw when we want gtest to skip this test case
+struct ROCFFT_GTEST_SKIP
+{
+    std::stringstream msg;
+};
+
+// exception type to throw when we want gtest to fail this test case
+struct ROCFFT_GTEST_FAIL
+{
+    std::stringstream msg;
+};
+
+#endif

--- a/shared/params_gen.h
+++ b/shared/params_gen.h
@@ -24,8 +24,8 @@
 
 #include <vector>
 
-#include "../../shared/fft_params.h"
-#include "../../shared/test_params.h"
+#include "fft_params.h"
+#include "test_params.h"
 
 const static std::vector<size_t> batch_range = {2, 1};
 


### PR DESCRIPTION
6.2 cherry pick for https://ontrack-internal.amd.com/browse/SWDEV-465970.

Cherry picked commits: a241030, e823105, and c74e60d.