### PR TITLE
Require rocFFT use hip-config.cmake to find HIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ set(AMDGPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "Target default GPUs if AMDGPU
 rocm_check_target_ids(AMDGPU_TARGETS TARGETS "${AMDGPU_TARGETS}")
   
 # HIP is required - library and clients use HIP to access the device
-find_package( HIP REQUIRED )
+find_package( HIP REQUIRED CONFIG )
 
 # The nvidia backend can be used to compile for CUDA devices.
 # Specify the CUDA prefix in the CUDA_PREFIX variable.


### PR DESCRIPTION
Sometimes rocFFT use FindHIP.cmake which is not desired -- it does not have hip::device and hip::host target imported and result in cmake generating error.

Reference: https://bugs.gentoo.org/932155