### PR TITLE
Normalizes dependencies and fix build RPATH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,8 @@ set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for
   
 # HIP is required - library and clients use HIP to access the device
 find_package( HIP REQUIRED CONFIG )
+find_package( hiprtc REQUIRED CONFIG )
+find_package( Threads REQUIRED )
 
 # The nvidia backend can be used to compile for CUDA devices.
 # Specify the CUDA prefix in the CUDA_PREFIX variable.

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -51,13 +51,8 @@ if( USE_CUDA )
   set( ROCFFT_HOST_LINK_LIBS -lcuda )
   set( ROCFFT_RTC_LINK_LIBS -lnvrtc -lnvrtc-builtins -lnvptxcompiler_static )
 else()
-  set( ROCFFT_HOST_LINK_LIBS hip::host )
+  set( ROCFFT_HOST_LINK_LIBS hip::host hiprtc::hiprtc ${CMAKE_DL_LIBS} )
   set( ROCFFT_DEVICE_LINK_LIBS hip::device )
-  if( WIN32 )
-    set( ROCFFT_RTC_LINK_LIBS "${HIP_PATH}/lib/hiprtc.lib" )
-  else()
-    set( ROCFFT_RTC_LINK_LIBS -L${ROCM_PATH}/lib -lhiprtc -ldl )
-  endif()
 endif()
 
 if( ROCFFT_MPI_ENABLE )
@@ -79,7 +74,6 @@ target_include_directories( rocfft_rtc_helper
 set(APPEND_ROCMLIB_RPATH "\$ORIGIN/../../../lib")
 target_link_libraries( rocfft_rtc_helper PRIVATE rocfft-rtc-compile )
 set_target_properties( rocfft_rtc_helper PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON
-                                         BUILD_WITH_INSTALL_RPATH TRUE
                                          INSTALL_RPATH "${APPEND_ROCMLIB_RPATH}" )
 target_link_directories( rocfft_rtc_helper PRIVATE ${ROCFFT_HOST_LINK_DIRS} )
 
@@ -408,9 +402,7 @@ foreach( target rocfft rocfft_offline_tuner rocfft_solmap_convert rocfft_aot_hel
   endif()
 
   # RTC uses dladdr to find the RTC helper program
-  if( NOT WIN32 )
-    target_link_libraries( ${target} PUBLIC -ldl pthread )
-  endif()
+  target_link_libraries( ${target} PUBLIC ${CMAKE_DL_LIBS} Threads::Threads )
 
   target_include_directories( ${target}
     PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/library/src/include>
@@ -528,11 +520,9 @@ if ( ROCFFT_KERNEL_CACHE_ENABLE )
   list( REMOVE_ITEM GPU_TARGETS_AOT gfx1102 )
   list( REMOVE_ITEM GPU_TARGETS_AOT gfx1151 )
   list( REMOVE_ITEM GPU_TARGETS_AOT gfx1200 )
-  # The binary will be having relative RUNPATH with respect to install directory
-  # Set LD_LIBRARY_PATH for executing the binary from build directory.
   add_custom_command(
     OUTPUT rocfft_kernel_cache.db
-    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${ROCM_PATH}/${CMAKE_INSTALL_LIBDIR}" ./rocfft_aot_helper \"${ROCFFT_BUILD_KERNEL_CACHE_PATH}\" ${ROCFFT_KERNEL_CACHE_PATH} $<TARGET_FILE:rocfft_rtc_helper> ${GPU_TARGETS_AOT}
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/rocfft_aot_helper" \"${ROCFFT_BUILD_KERNEL_CACHE_PATH}\" ${ROCFFT_KERNEL_CACHE_PATH} $<TARGET_FILE:rocfft_rtc_helper> ${GPU_TARGETS_AOT}
     DEPENDS rocfft_aot_helper rocfft_rtc_helper
     COMMENT "Compile kernels into shipped cache file"
   )


### PR DESCRIPTION
* Switches from -ldl and pthread to more modern CMake constructs (removing WIN32 carveout).
* Uses find_package to locate hiprtc and depends on it as an imported library.
* Removes BUILD_WITH_INSTALL_RPATH as this results in a broken build layout (this option should only be used in rare cases where the install RPATH is origin-relative *and* the build and install directory layout is the same, which it is not here).
* The above allowed the LD_LIBRARY_PATH hack to be removed because CMake build rpaths are always set to an absolute path by default, making them usable from the build tree without further intervention.