### PR TITLE
Generate code coverage reports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,11 +327,3 @@ rocm_create_package(
 )
 
 option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
-
-if(BUILD_CODE_COVERAGE)
-  add_custom_target(coverage_cleanup
-    COMMAND find ${CMAKE_BINARY_DIR} -name *.profraw -delete
-    COMMAND find ${CMAKE_BINARY_DIR} -name *.profdata -delete
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,3 +325,13 @@ rocm_create_package(
     LDCONFIG
     LDCONFIG_DIR ${ROCFFT_CONFIG_DIR}
 )
+
+option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
+
+if(BUILD_CODE_COVERAGE)
+  add_custom_target(coverage_cleanup
+    COMMAND find ${CMAKE_BINARY_DIR} -name *.profraw -delete
+    COMMAND find ${CMAKE_BINARY_DIR} -name *.profdata -delete
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+endif()

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can install rocFFT using pre-built packages or building from source.
     You can generate a test coverage report with the following:
     ```bash
     cmake -DCMAKE_CXX_COMPILER=amdclang++ -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CODE_COVERAGE=ON <optional: -DCOVERAGE_TEST_OPTIONS="cmdline args to pass to rocfft-test (default: --smoketest)"> ..
-    make -j && make coverage
+    make -j coverage
     ```
     The above will output the coverage report to the terminal and also save an html coverage report to $PWD/coverage-report.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ You can install rocFFT using pre-built packages or building from source.
     | `rocfft-bench` | `-DBUILD_CLIENTS_BENCH=on` | hipRAND |
     | `rocfft-test` | `-DBUILD_CLIENTS_TESTS=on` | hipRAND, FFTW, GoogleTest |
     | samples | `-DBUILD_CLIENTS_SAMPLES=on` | None |
+    | coverage | `-DBUILD_CODE_COVERAGE=ON` | clang, llvm-cov |
 
     Clients are not built by default. To build them, use `-DBUILD_CLIENTS=on`. The build process
     downloads and builds GoogleTest and FFTW if they are not already installed.
@@ -81,6 +82,13 @@ You can install rocFFT using pre-built packages or building from source.
     ```
 
     We use version 1.11 of GoogleTest.
+
+    You can generate a test coverage report with the following:
+    ```bash
+    cmake -DCMAKE_CXX_COMPILER=amdclang++ -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CODE_COVERAGE=ON <optional: -DCOVERAGE_TEST_OPTIONS="cmdline args to pass to rocfft-test (default: --smoketest)"> ..
+    make -j && make coverage
+    ```
+    The above will output the coverage report to the terminal and also save an html coverage report to $PWD/coverage-report.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can install rocFFT using pre-built packages or building from source.
     cmake -DCMAKE_CXX_COMPILER=amdclang++ -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CODE_COVERAGE=ON <optional: -DCOVERAGE_TEST_OPTIONS="cmdline args to pass to rocfft-test (default: --smoketest)"> ..
     make -j coverage
     ```
-    The above will output the coverage report to the terminal and also save an html coverage report to $PWD/coverage-report.
+    The above will output the coverage report to the terminal and also save an html coverage report to `$PWD/coverage-report`.
 
 ## Examples
 

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -390,7 +390,7 @@ if( ROCFFT_MPI_ENABLE )
 
 endif()
 
-set(COVERAGE_TEST_OPTIONS "--smoketest" CACHE STRING "Command line arguments for rocfft-test")
+set(COVERAGE_TEST_OPTIONS "--smoketest" CACHE STRING "Command line arguments for rocfft-test when generating a code coverage report")
 
 if(BUILD_CODE_COVERAGE)
   # Coverage won't work in a standalone build of the tests, as we can't

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -389,3 +389,46 @@ if( ROCFFT_MPI_ENABLE )
   )
 
 endif()
+
+if(BUILD_CODE_COVERAGE)
+  # Coverage won't work in a standalone build of the tests, as we can't
+  # guarantee the library was built with coverage enabled
+  if( NOT TARGET rocfft )
+    message( FATAL_ERROR "BUILD_CODE_COVERAGE requires building from the root of rocFFT" )
+  endif()
+
+  add_custom_target(
+    code_cov_tests
+    DEPENDS rocfft-test rocfft_rtc_helper
+    COMMAND ${CMAKE_COMMAND} -E rm -rf ./coverage-report
+    COMMAND ${CMAKE_COMMAND} -E make_directory ./coverage-report/profraw
+    COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE="./coverage-report/profraw/rocfft-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG $<TARGET_FILE:rocfft-test> --precompile=rocfft-test-precompile.db --smoketest
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
+  find_program(
+    LLVM_PROFDATA
+    llvm-profdata
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
+
+  find_program(
+    LLVM_COV
+    llvm-cov
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
+
+  add_custom_target(
+    coverage
+    DEPENDS code_cov_tests
+    COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/rocfft-coverage_*.profraw -o ./coverage-report/rocfft.profdata
+    COMMAND ${LLVM_COV} report -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata
+    COMMAND ${LLVM_COV} show -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata -format=html -output-dir=coverage-report
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
+endif()

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -390,6 +390,8 @@ if( ROCFFT_MPI_ENABLE )
 
 endif()
 
+set(COVERAGE_TEST_OPTIONS "--smoketest" CACHE STRING "Command line arguments for rocfft-test")
+
 if(BUILD_CODE_COVERAGE)
   # Coverage won't work in a standalone build of the tests, as we can't
   # guarantee the library was built with coverage enabled
@@ -402,7 +404,7 @@ if(BUILD_CODE_COVERAGE)
     DEPENDS rocfft-test rocfft_rtc_helper
     COMMAND ${CMAKE_COMMAND} -E rm -rf ./coverage-report
     COMMAND ${CMAKE_COMMAND} -E make_directory ./coverage-report/profraw
-    COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE="./coverage-report/profraw/rocfft-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG $<TARGET_FILE:rocfft-test> --precompile=rocfft-test-precompile.db --smoketest
+    COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE="./coverage-report/profraw/rocfft-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG $<TARGET_FILE:rocfft-test> --precompile=rocfft-test-precompile.db ${COVERAGE_TEST_OPTIONS}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -625,4 +625,10 @@ if(BUILD_CODE_COVERAGE)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 
+  add_custom_target(
+    code_coverage_report
+    COMMAND /opt/rocm/llvm/bin/llvm-profdata merge -sparse ./coverage-report/profraw/rocfft-coverage_*.profraw -o ./coverage-report/rocfft.profdata
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
 endif()

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -617,4 +617,12 @@ if(BUILD_CODE_COVERAGE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate")
+
+  add_custom_target(
+    code_cov_tests
+    COMMAND echo Coverage GTEST_FILTER=\${GTEST_FILTER}
+    COMMAND mkdir -p ./coverage-report/profraw/ && rm -rf ./coverage-report/profraw/* && LLVM_PROFILE_FILE="./coverage-report/profraw/rocfft-coverage_%p.profraw" ROCM_PATH=/opt/rocm GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./clients/staging/rocfft-test --precompile=rocfft-test-precompile.db  --gtest_color=yes --R 80 --nrand 10 --gtest_filter=\"\${GTEST_FILTER}\"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
 endif()

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -626,19 +626,21 @@ if(BUILD_CODE_COVERAGE)
   )
 
   add_custom_target(
-    code_coverage_report
+    coverage
     COMMAND /opt/rocm/llvm/bin/llvm-profdata merge -sparse ./coverage-report/profraw/rocfft-coverage_*.profraw -o ./coverage-report/rocfft.profdata
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 
+  add_dependencies(coverage code_cov_tests)
+
   add_custom_command(
-    TARGET code_coverage_report
+    TARGET coverage
     COMMAND /opt/rocm/llvm/bin/llvm-cov report -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 
   add_custom_command(
-    TARGET code_coverage_report
+    TARGET coverage
     COMMAND /opt/rocm/llvm/bin/llvm-cov show -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata -format=html -output-dir=coverage_report
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -621,7 +621,7 @@ if(BUILD_CODE_COVERAGE)
   add_custom_target(
     code_cov_tests
     COMMAND echo Coverage GTEST_FILTER=\${GTEST_FILTER}
-    COMMAND mkdir -p ./coverage-report/profraw/ && rm -rf ./coverage-report/profraw/* && LLVM_PROFILE_FILE="./coverage-report/profraw/rocfft-coverage_%p.profraw" ROCM_PATH=/opt/rocm GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./clients/staging/rocfft-test --precompile=rocfft-test-precompile.db  --gtest_color=yes --R 80 --nrand 10 --gtest_filter=\"\${GTEST_FILTER}\"
+    COMMAND mkdir -p ./coverage-report/profraw/ && rm -rf ./coverage-report/profraw/* && LLVM_PROFILE_FILE="./coverage-report/profraw/rocfft-coverage_%p.profraw" ROCM_PATH=/opt/rocm GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./clients/staging/rocfft-test --precompile=./clients/staging/rocfft-test-precompile.db  --gtest_color=yes --R 80 --nrand 10 --gtest_filter=\"\${GTEST_FILTER}\"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -641,7 +641,7 @@ if(BUILD_CODE_COVERAGE)
 
   add_custom_command(
     TARGET coverage
-    COMMAND /opt/rocm/llvm/bin/llvm-cov show -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata -format=html -output-dir=coverage_report
+    COMMAND /opt/rocm/llvm/bin/llvm-cov show -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata -format=html -output-dir=coverage-report
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -609,3 +609,12 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
         DESTINATION "." )
   message( STATUS "Backward Compatible Sym Link Created for include directories" )
 endif()
+
+option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
+
+if(BUILD_CODE_COVERAGE)
+  set(COVERAGE_COMPILE_FLAGS "-g -O0 -fprofile-instr-generate -fcoverage-mapping")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate")
+endif()

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -44,6 +44,14 @@ function( rocfft_link_internal_lib target lib )
   )
 endfunction()
 
+# Add code coverage flags to a library target, if enabled
+function( rocfft_add_coverage_flags target )
+  if( BUILD_CODE_COVERAGE )
+    target_compile_options( ${target} PRIVATE -g -O0 -fprofile-instr-generate -fcoverage-mapping )
+    target_link_options( ${target} INTERFACE -fprofile-instr-generate )
+  endif()
+endfunction()
+
 add_executable( rocfft_rtc_helper rocfft_rtc_helper.cpp )
 
 # each backend requires different libraries for host and device code
@@ -334,6 +342,7 @@ foreach( target
     target_compile_options( ${target} PRIVATE -Og )
   endif()
   target_link_libraries( ${target} PUBLIC ${ROCFFT_HOST_LINK_LIBS} ${ROCFFT_RTC_LINK_LIBS} )
+  rocfft_add_coverage_flags( ${target} )
   target_link_directories( ${target} PRIVATE ${ROCFFT_HOST_LINK_DIRS} )
 
 endforeach()
@@ -372,6 +381,7 @@ add_library( rocfft
   ${rocfft_source}
   ${relative_rocfft_headers_public}
   )
+rocfft_add_coverage_flags( rocfft )
 
 if( ROCFFT_MPI_ENABLE )
   target_compile_definitions(rocfft PRIVATE ROCFFT_MPI_ENABLE)
@@ -608,41 +618,4 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
        "${PROJECT_BINARY_DIR}/rocfft"
         DESTINATION "." )
   message( STATUS "Backward Compatible Sym Link Created for include directories" )
-endif()
-
-option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
-
-if(BUILD_CODE_COVERAGE)
-  set(COVERAGE_COMPILE_FLAGS "-g -O0 -fprofile-instr-generate -fcoverage-mapping")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILE_FLAGS}")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate")
-
-  add_custom_target(
-    code_cov_tests
-    COMMAND echo Coverage GTEST_FILTER=\${GTEST_FILTER}
-    COMMAND mkdir -p ./coverage-report/profraw/ && rm -rf ./coverage-report/profraw/* && LLVM_PROFILE_FILE="./coverage-report/profraw/rocfft-coverage_%p.profraw" ROCM_PATH=/opt/rocm GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./clients/staging/rocfft-test --precompile=./clients/staging/rocfft-test-precompile.db  --gtest_color=yes --R 80 --nrand 10 --gtest_filter=\"\${GTEST_FILTER}\"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
-
-  add_custom_target(
-    coverage
-    COMMAND /opt/rocm/llvm/bin/llvm-profdata merge -sparse ./coverage-report/profraw/rocfft-coverage_*.profraw -o ./coverage-report/rocfft.profdata
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
-
-  add_dependencies(coverage code_cov_tests)
-
-  add_custom_command(
-    TARGET coverage
-    COMMAND /opt/rocm/llvm/bin/llvm-cov report -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
-
-  add_custom_command(
-    TARGET coverage
-    COMMAND /opt/rocm/llvm/bin/llvm-cov show -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata -format=html -output-dir=coverage-report
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
-
 endif()

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -631,4 +631,16 @@ if(BUILD_CODE_COVERAGE)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 
+  add_custom_command(
+    TARGET code_coverage_report
+    COMMAND /opt/rocm/llvm/bin/llvm-cov report -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
+  add_custom_command(
+    TARGET code_coverage_report
+    COMMAND /opt/rocm/llvm/bin/llvm-cov show -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata -format=html -output-dir=coverage_report
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
 endif()

--- a/library/src/device/CMakeLists.txt
+++ b/library/src/device/CMakeLists.txt
@@ -98,6 +98,11 @@ add_library( rocfft-function-pool OBJECT
   ${FUNCTION_POOLS}
   function_pool.cpp
 )
+# Don't add function pool to coverage as it's just generated code
+# that sets up kernel config data structures, and isn't interesting
+# to cover.
+#rocfft_add_coverage_flags( rocfft-function-pool )
+
 target_include_directories( rocfft-function-pool
   PRIVATE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/library/src/device>

--- a/library/src/device/generator/CMakeLists.txt
+++ b/library/src/device/generator/CMakeLists.txt
@@ -21,6 +21,7 @@
 # #############################################################################
 
 add_library( generator OBJECT generator.cpp fftgenerator.cpp )
+rocfft_add_coverage_flags( generator )
 
 add_executable( stockham_gen stockham_gen.cpp )
 target_link_libraries( stockham_gen PRIVATE generator )


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
- Added BUILD_CODE_COVERAGE define to add proper flags for instrumentation with llvm
- Added a target for running tests, which generates raw code coverage profile
- Added a target to merge the raw data into a code coverage report, which both prints to the terminal and generates an html report

To test:
```bash
# from project root
mkdir build && cd build
cmake -DCMAKE_CXX_COMPILER=amdclang++ -DCMAKE_C_COMPILER=amdclang \
    -DGPU_TARGETS=<gpu-target> -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON \
    -DBUILD_CLIENTS_BENCH=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_CODE_COVERAGE=ON .. \ 
    &&  make code_cov_tests code_coverage_report
```
