### PR TITLE
add single-precision kernels for lengths 4704, 5488, 6144, 6561, 8192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Documentation for rocFFT is available at
 
 ## rocFFT 1.0.34 (unreleased)
 
+### Optimized
+
+* Implemented single-precision 1D kernels for lengths:
+  - 4704
+  - 5488
+  - 6144
+  - 6561
+  - 8192
+
 ### Removed
 
 * Removed rocfft-rider legacy compatibility from clients

--- a/library/solution_map/gfx908_rocfft_solution_map.dat
+++ b/library/solution_map/gfx908_rocfft_solution_map.dat
@@ -222,9 +222,6 @@
 {"Problem":{"arch":"gfx908","token":"sbrc_xy_z_256_sp_ip_complex"},
  "Solutions":[ {"sol_node_type":"SOL_LEAF_NODE","using_scheme":"CS_KERNEL_STOCKHAM_TRANSPOSE_XY_Z","solution_childnodes":[ {"child_token":"kernel_len256_single_sbrc_xy_z","child_option":0} ]}
                ]},
-{"Problem":{"arch":"gfx908","token":"14348907_sp_ip_complex"},
- "Solutions":[ {"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_TRTRT","solution_childnodes":[ {"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"6561_sp_ip_complex","child_option":1},{"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"2187_sp_ip_complex","child_option":1},{"child_token":"leafnode_token_builtin_kernel","child_option":0} ]}
-               ]},
 {"Problem":{"arch":"gfx908","token":"16777216_sp_ip_complex"},
  "Solutions":[ {"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_TRTRT","solution_childnodes":[ {"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"4096_sp_ip_complex","child_option":1},{"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"4096_sp_ip_complex","child_option":2},{"child_token":"leafnode_token_builtin_kernel","child_option":0} ]}
                ]},
@@ -255,20 +252,11 @@
 {"Problem":{"arch":"gfx908","token":"43008_dp_op_complex"},
  "Solutions":[ {"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_CC","solution_childnodes":[ {"child_token":"sbcc_168_dp_ip_complex","child_option":4},{"child_token":"sbrc_256_dp_ip_complex","child_option":2} ]}
                ]},
-{"Problem":{"arch":"gfx908","token":"6561_sp_ip_complex"},
- "Solutions":[ {"sol_node_type":"SOL_DUMMY","using_scheme":"CS_NONE","solution_childnodes":[  ]}
-              ,{"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_CC","solution_childnodes":[ {"child_token":"sbcc_81_sp_ip_complex","child_option":0},{"child_token":"sbrc_81_sp_ip_complex","child_option":0} ]}
-              ,{"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_CC","solution_childnodes":[ {"child_token":"sbcc_81_sp_ip_complex","child_option":1},{"child_token":"sbrc_81_sp_ip_complex","child_option":0} ]}
-              ,{"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_CC","solution_childnodes":[ {"child_token":"sbcc_81_sp_ip_complex","child_option":2},{"child_token":"sbrc_81_sp_ip_complex","child_option":0} ]}
-               ]},
 {"Problem":{"arch":"gfx908","token":"8192_dp_op_complex"},
  "Solutions":[ {"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_CC","solution_childnodes":[ {"child_token":"sbcc_64_dp_ip_complex","child_option":3},{"child_token":"sbrc_128_dp_ip_complex","child_option":0} ]}
                ]},
 {"Problem":{"arch":"gfx908","token":"4096_4096_sp_ip_complex"},
  "Solutions":[ {"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_2D_RTRT","solution_childnodes":[ {"child_token":"4096_sp_ip_complex","child_option":3},{"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"4096_sp_ip_complex","child_option":1},{"child_token":"leafnode_token_builtin_kernel","child_option":0} ]}
-               ]},
-{"Problem":{"arch":"gfx908","token":"6561_6561_sp_ip_complex"},
- "Solutions":[ {"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_2D_RTRT","solution_childnodes":[ {"child_token":"6561_sp_ip_complex","child_option":2},{"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"6561_sp_ip_complex","child_option":3},{"child_token":"leafnode_token_builtin_kernel","child_option":0} ]}
                ]},
 {"Problem":{"arch":"gfx908","token":"125_125_sp_ip_complex"},
  "Solutions":[ {"sol_node_type":"SOL_DUMMY","using_scheme":"CS_NONE","solution_childnodes":[  ]}

--- a/library/solution_map/gfx90a_rocfft_solution_map.dat
+++ b/library/solution_map/gfx90a_rocfft_solution_map.dat
@@ -1471,9 +1471,6 @@
 {"Problem":{"arch":"gfx90a","token":"96_96_96_sp_op_real_fwd"},
  "Solutions":[ {"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_REAL_3D_EVEN","solution_childnodes":[ {"child_token":"96_sp_ip_complex","child_option":10},{"child_token":"sbcc_96_sp_ip_complex","child_option":3},{"child_token":"sbcc_96_sp_ip_complex","child_option":2} ]}
                ]},
-{"Problem":{"arch":"gfx90a","token":"14348907_sp_ip_complex"},
- "Solutions":[ {"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_TRTRT","solution_childnodes":[ {"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"6561_sp_ip_complex","child_option":3},{"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"2187_sp_ip_complex","child_option":2},{"child_token":"leafnode_token_builtin_kernel","child_option":0} ]}
-               ]},
 {"Problem":{"arch":"gfx90a","token":"16777216_sp_ip_complex"},
  "Solutions":[ {"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_TRTRT","solution_childnodes":[ {"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"4096_sp_ip_complex","child_option":1},{"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"4096_sp_ip_complex","child_option":1},{"child_token":"leafnode_token_builtin_kernel","child_option":0} ]}
                ]},
@@ -1508,12 +1505,6 @@
 {"Problem":{"arch":"gfx90a","token":"43008_dp_op_complex"},
  "Solutions":[ {"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_CC","solution_childnodes":[ {"child_token":"sbcc_224_dp_ip_complex","child_option":0},{"child_token":"sbrc_192_dp_ip_complex","child_option":2} ]}
                ]},
-{"Problem":{"arch":"gfx90a","token":"6561_sp_ip_complex"},
- "Solutions":[ {"sol_node_type":"SOL_DUMMY","using_scheme":"CS_NONE","solution_childnodes":[  ]}
-              ,{"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_CC","solution_childnodes":[ {"child_token":"sbcc_81_sp_ip_complex","child_option":0},{"child_token":"sbrc_81_sp_ip_complex","child_option":0} ]}
-              ,{"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_CC","solution_childnodes":[ {"child_token":"sbcc_81_sp_ip_complex","child_option":0},{"child_token":"sbrc_81_sp_ip_complex","child_option":1} ]}
-              ,{"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_CC","solution_childnodes":[ {"child_token":"sbcc_81_sp_ip_complex","child_option":1},{"child_token":"sbrc_81_sp_ip_complex","child_option":2} ]}
-               ]},
 {"Problem":{"arch":"gfx90a","token":"8192_dp_ip_complex"},
  "Solutions":[ {"sol_node_type":"SOL_DUMMY","using_scheme":"CS_NONE","solution_childnodes":[  ]}
               ,{"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_L1D_CC","solution_childnodes":[ {"child_token":"sbcc_64_dp_ip_complex","child_option":2},{"child_token":"sbrc_128_dp_ip_complex","child_option":2} ]}
@@ -1529,9 +1520,6 @@
 {"Problem":{"arch":"gfx90a","token":"55_55_dp_ip_complex"},
  "Solutions":[ {"sol_node_type":"SOL_DUMMY","using_scheme":"CS_NONE","solution_childnodes":[  ]}
               ,{"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_2D_RTRT","solution_childnodes":[ {"child_token":"55_dp_ip_complex","child_option":1},{"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"55_dp_ip_complex","child_option":2},{"child_token":"leafnode_token_builtin_kernel","child_option":0} ]}
-               ]},
-{"Problem":{"arch":"gfx90a","token":"6561_6561_sp_ip_complex"},
- "Solutions":[ {"sol_node_type":"SOL_INTERNAL_NODE","using_scheme":"CS_2D_RTRT","solution_childnodes":[ {"child_token":"6561_sp_ip_complex","child_option":2},{"child_token":"leafnode_token_builtin_kernel","child_option":0},{"child_token":"6561_sp_ip_complex","child_option":2},{"child_token":"leafnode_token_builtin_kernel","child_option":0} ]}
                ]},
 {"Problem":{"arch":"gfx90a","token":"125_125_sp_ip_complex"},
  "Solutions":[ {"sol_node_type":"SOL_DUMMY","using_scheme":"CS_NONE","solution_childnodes":[  ]}

--- a/library/src/device/generator/stockham_gen.cpp
+++ b/library/src/device/generator/stockham_gen.cpp
@@ -21,6 +21,7 @@
 #include <functional>
 using namespace std::placeholders;
 
+#include "../../../../shared/precision_type.h"
 #include "generator.h"
 #include "stockham_gen.h"
 #include <array>
@@ -262,6 +263,18 @@ void stockham_variants(const std::string&            kernel_name,
     output << "]";
 }
 
+static size_t max_bytes_per_element(const std::vector<unsigned int>& precisions)
+{
+    // generate for the maximum element size in the available
+    // precisions
+    size_t element_size = 0;
+    for(auto p : precisions)
+    {
+        element_size = std::max(element_size, complex_type_size(static_cast<rocfft_precision>(p)));
+    }
+    return element_size;
+}
+
 int main()
 {
     std::string line;
@@ -326,6 +339,8 @@ int main()
         StockhamGeneratorSpecs specs(factors, factors2d, precisions, workgroup_size, scheme);
         specs.half_lds           = half_lds;
         specs.direct_to_from_reg = direct_to_from_reg;
+
+        specs.bytes_per_element = max_bytes_per_element(precisions);
 
         specs.threads_per_transform = threads_per_transform.front();
 

--- a/library/src/device/kernel-generator.py
+++ b/library/src/device/kernel-generator.py
@@ -700,6 +700,11 @@ def list_small_kernels():
         NS(length=4000, workgroup_size=256, threads_per_transform=200, factors=(10, 10, 10, 4), runtime_compile=True),
         NS(length=4050, workgroup_size=256, threads_per_transform=135, factors=(10, 5, 3, 3, 3, 3), runtime_compile=True),
         NS(length=4096, workgroup_size=256, threads_per_transform=256, factors=(16, 16, 16), runtime_compile=True),
+        NS(length=4704, workgroup_size=256, threads_per_transform=224, factors=(8, 4, 7, 7, 3), double_precision=False, runtime_compile=True),
+        NS(length=5488, workgroup_size=256, threads_per_transform=196, factors=(7, 4, 7, 4, 7), double_precision=False, runtime_compile=True),
+        NS(length=6144, workgroup_size=256, threads_per_transform=192, factors=(8, 4, 4, 6, 8), double_precision=False, runtime_compile=True),
+        NS(length=6561, workgroup_size=256, threads_per_transform=243, factors=(3, 3, 3, 3, 3, 3, 3, 3), double_precision=False, runtime_compile=True),
+        NS(length=8192, workgroup_size=256, threads_per_transform=256, factors=(8, 8, 8, 4, 4), double_precision=False, runtime_compile=True),
     ]
 
     kernels = [NS(**kernel.__dict__,

--- a/library/src/device/kernel-generator.py
+++ b/library/src/device/kernel-generator.py
@@ -704,7 +704,7 @@ def list_small_kernels():
 
     kernels = [NS(**kernel.__dict__,
                   scheme='CS_KERNEL_STOCKHAM',
-                  precision=['sp', 'dp']) for kernel in kernels1d]
+                  precision=['sp','dp'] if not hasattr(kernel, 'double_precision') or kernel.double_precision else ['sp']) for kernel in kernels1d]
 
     return kernels
 
@@ -1119,6 +1119,9 @@ def generate_kernels(kernels, precisions, stockham_gen):
         # Send input if any remaining
         if kernel_idx < num_kernels:
             k = kernels[kernel_idx]
+
+            kernel_precisions = k.precision if hasattr(k, 'precision') else precisions
+
             # 2D single kernels always specify threads per transform
             if isinstance(k.length, list):
                 proc.stdin.write(','.join([str(f)
@@ -1126,13 +1129,13 @@ def generate_kernels(kernels, precisions, stockham_gen):
                 proc.stdin.write(','.join([str(f)
                                            for f in k.factors[1]]) + " ")
                 proc.stdin.write(
-                    ','.join([str(pre_enum[pre]) for pre in precisions]) + " ")
+                    ','.join([str(pre_enum[pre]) for pre in kernel_precisions]) + " ")
                 proc.stdin.write(','.join(
                     [str(f) for f in k.threads_per_transform]))
             else:
                 proc.stdin.write(','.join([str(f) for f in k.factors]) + " ")
                 proc.stdin.write(','.join(
-                    [str(pre_enum[pre]) for pre in precisions]))
+                    [str(pre_enum[pre]) for pre in kernel_precisions]))
                 # 1D kernels might not, and need to default to 'uwide'
                 threads_per_transform = getattr(
                     k, 'threads_per_transform', {

--- a/library/src/device/kernel-generator.py
+++ b/library/src/device/kernel-generator.py
@@ -702,9 +702,9 @@ def list_small_kernels():
         NS(length=4096, workgroup_size=256, threads_per_transform=256, factors=(16, 16, 16), runtime_compile=True),
         NS(length=4704, workgroup_size=256, threads_per_transform=224, factors=(8, 4, 7, 7, 3), double_precision=False, runtime_compile=True),
         NS(length=5488, workgroup_size=256, threads_per_transform=196, factors=(7, 4, 7, 4, 7), double_precision=False, runtime_compile=True),
-        NS(length=6144, workgroup_size=256, threads_per_transform=192, factors=(8, 4, 4, 6, 8), double_precision=False, runtime_compile=True),
+        NS(length=6144, workgroup_size=512, threads_per_transform=512, factors=(16, 4, 8, 3, 4), double_precision=False, runtime_compile=True),
         NS(length=6561, workgroup_size=256, threads_per_transform=243, factors=(3, 3, 3, 3, 3, 3, 3, 3), double_precision=False, runtime_compile=True),
-        NS(length=8192, workgroup_size=256, threads_per_transform=256, factors=(8, 8, 8, 4, 4), double_precision=False, runtime_compile=True),
+        NS(length=8192, workgroup_size=512, threads_per_transform=512, factors=(16, 4, 4, 4, 8), double_precision=False, runtime_compile=True),
     ]
 
     kernels = [NS(**kernel.__dict__,

--- a/library/src/device/kernel-generator.py
+++ b/library/src/device/kernel-generator.py
@@ -1125,7 +1125,8 @@ def generate_kernels(kernels, precisions, stockham_gen):
         if kernel_idx < num_kernels:
             k = kernels[kernel_idx]
 
-            kernel_precisions = k.precision if hasattr(k, 'precision') else precisions
+            kernel_precisions = k.precision if hasattr(
+                k, 'precision') else precisions
 
             # 2D single kernels always specify threads per transform
             if isinstance(k.length, list):
@@ -1134,7 +1135,8 @@ def generate_kernels(kernels, precisions, stockham_gen):
                 proc.stdin.write(','.join([str(f)
                                            for f in k.factors[1]]) + " ")
                 proc.stdin.write(
-                    ','.join([str(pre_enum[pre]) for pre in kernel_precisions]) + " ")
+                    ','.join([str(pre_enum[pre])
+                              for pre in kernel_precisions]) + " ")
                 proc.stdin.write(','.join(
                     [str(f) for f in k.threads_per_transform]))
             else:

--- a/library/src/include/node_factory.h
+++ b/library/src/include/node_factory.h
@@ -61,7 +61,8 @@ public:
     static ComputeScheme
         DecideNodeScheme(const function_pool& pool, NodeMetaData& nodeData, TreeNode* parent);
     static ComputeScheme DecideRealScheme(const function_pool& pool, NodeMetaData& nodeData);
-    static ComputeScheme Decide1DScheme(const function_pool& pool, NodeMetaData& nodeData);
+    static ComputeScheme
+        Decide1DScheme(const function_pool& pool, NodeMetaData& nodeData, TreeNode* parent);
     static ComputeScheme Decide2DScheme(const function_pool& pool, NodeMetaData& nodeData);
     static ComputeScheme Decide3DScheme(const function_pool& pool, NodeMetaData& nodeData);
 

--- a/library/src/include/node_factory.h
+++ b/library/src/include/node_factory.h
@@ -32,6 +32,12 @@ private:
     static const Map1DLength         map1DLengthSingle;
     static const Map1DLength         map1DLengthDouble;
 
+    // Maps from length[0] to divLength1 for TRTRT decomposition.
+    // Normally we would choose the largest kernel that helps decompose
+    // a 1D length, but this map holds exceptions that are known to be
+    // better
+    static const Map1DLength map1DLengthTRTRT;
+
     static bool Large1DLengthsValid(const function_pool& pool,
                                     const Map1DLength&   map1DLength,
                                     rocfft_precision     precision);

--- a/library/src/node_factory.cpp
+++ b/library/src/node_factory.cpp
@@ -206,6 +206,12 @@ NodeFactory::Map1DLength const NodeFactory::map1DLengthDouble = {
     {114688, 224}, //           CC (224cc + 512rc)
 };
 
+NodeFactory::Map1DLength const NodeFactory::map1DLengthTRTRT = {
+    // 3^18 performs better when decomposing with 3^7 kernel even when
+    // 3^8 is available
+    {387420489, 177147},
+};
+
 //
 // Factorisation helpers
 //
@@ -747,20 +753,29 @@ ComputeScheme
         if(failed)
         {
             scheme = CS_L1D_TRTRT;
-            divLength1
-                = get_explicitly_supported_factor(pool, nodeData.precision, nodeData.length[0]);
-            if(divLength1 == 0)
-            {
-                // We need to recurse.  Note, for CS_L1D_TRTRT,
-                // divLength0 has to be explictly supported
-                auto divLength0
-                    = get_largest_supported_factor(pool, nodeData.precision, nodeData.length[0]);
 
-                // should ignore factor 1 or we're going into a infinity decompostion loop,
-                // (an example is to run len-81 when we build only pow2 kernels, we'll be here)
-                divLength1 = (divLength0 <= 1) ? 0 : nodeData.length[0] / divLength0;
+            auto it = map1DLengthTRTRT.find(nodeData.length[0]);
+            if(it != map1DLengthTRTRT.end())
+            {
+                divLength1 = it->second;
             }
-            failed = divLength1 == 0;
+            else
+            {
+                divLength1
+                    = get_explicitly_supported_factor(pool, nodeData.precision, nodeData.length[0]);
+                if(divLength1 == 0)
+                {
+                    // We need to recurse.  Note, for CS_L1D_TRTRT,
+                    // divLength0 has to be explictly supported
+                    auto divLength0 = get_largest_supported_factor(
+                        pool, nodeData.precision, nodeData.length[0]);
+
+                    // should ignore factor 1 or we're going into a infinity decompostion loop,
+                    // (an example is to run len-81 when we build only pow2 kernels, we'll be here)
+                    divLength1 = (divLength0 <= 1) ? 0 : nodeData.length[0] / divLength0;
+                }
+                failed = divLength1 == 0;
+            }
         }
     }
 

--- a/library/src/node_factory.cpp
+++ b/library/src/node_factory.cpp
@@ -563,7 +563,7 @@ ComputeScheme NodeFactory::DecideNodeScheme(const function_pool& pool,
     switch(nodeData.dimension)
     {
     case 1:
-        return Decide1DScheme(pool, nodeData);
+        return Decide1DScheme(pool, nodeData, parent);
     case 2:
         return Decide2DScheme(pool, nodeData);
     case 3:
@@ -598,7 +598,8 @@ ComputeScheme NodeFactory::DecideRealScheme(const function_pool& pool, NodeMetaD
     return CS_REAL_TRANSFORM_USING_CMPLX;
 }
 
-ComputeScheme NodeFactory::Decide1DScheme(const function_pool& pool, NodeMetaData& nodeData)
+ComputeScheme
+    NodeFactory::Decide1DScheme(const function_pool& pool, NodeMetaData& nodeData, TreeNode* parent)
 {
     ComputeScheme scheme = CS_NONE;
 
@@ -608,7 +609,32 @@ ComputeScheme NodeFactory::Decide1DScheme(const function_pool& pool, NodeMetaDat
 
     if(pool.has_function(FMKey(nodeData.length[0], nodeData.precision)))
     {
-        return CS_KERNEL_STOCKHAM;
+        // 2-kernel plans for lengths > 4k can still do better at
+        // smaller batch size due to using more CUs.  So prefer
+        // single-kernel only if we launch enough workgroups for all
+        // CUs
+        if(nodeData.length[0] > 4096)
+        {
+            auto kernel = pool.get_kernel(FMKey(nodeData.length[0], nodeData.precision));
+
+            // higher dimensions and batch is the effective batch for
+            // the kernel
+            const auto totalBatch
+                = product(nodeData.length.begin() + 1, nodeData.length.end()) * nodeData.batch;
+
+            // Bluestein would have chosen this kernel for
+            // single-kernel Bluestein, so continue using it for
+            // chirp setup
+            if((parent && parent->scheme == CS_BLUESTEIN)
+               || totalBatch / kernel.transforms_per_block
+                      >= static_cast<size_t>(pool.deviceProp->multiProcessorCount))
+                return CS_KERNEL_STOCKHAM;
+            // otherwise, fall through to multi-kernel plan
+        }
+        else
+        {
+            return CS_KERNEL_STOCKHAM;
+        }
     }
 
     size_t divLength1 = 1;

--- a/library/src/node_factory.cpp
+++ b/library/src/node_factory.cpp
@@ -758,6 +758,7 @@ ComputeScheme
             if(it != map1DLengthTRTRT.end())
             {
                 divLength1 = it->second;
+                failed     = false;
             }
             else
             {


### PR DESCRIPTION
64kiB LDS is still plenty to implement some larger 1D lengths, for single-precision.

Tested on gfx900, 908, 90a, 942, 1030, 1100, 1102 and it looks good all around.  The heuristic looks conservative enough to be safe.

Speedups range from 1.11 for a length like 14348907 (which uses 6561 as a sub-problem) to over 2x on large batch lengths like 4704 and 6144, on some architectures.