### PR TITLE
Add printf to the code generator

### DIFF
--- a/library/src/device/generator/generator.h
+++ b/library/src/device/generator/generator.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <regex>
 #include <string.h>
 #include <string>
 #include <variant>
@@ -628,6 +629,7 @@ class Butterfly;
 class IntrinsicStore;
 class IntrinsicStorePlanar;
 class IntrinsicLoadToDest;
+class Printf;
 
 struct LineBreak
 {
@@ -704,7 +706,8 @@ using Statement = std::variant<Assign,
                                Butterfly,
                                IntrinsicStore,
                                IntrinsicStorePlanar,
-                               IntrinsicLoadToDest>;
+                               IntrinsicLoadToDest,
+                               Printf>;
 
 class Assign
 {
@@ -1092,6 +1095,28 @@ public:
     Expression rw_flag;
 };
 
+class Printf
+{
+public:
+    const char*             fmt;
+    std::vector<Expression> args;
+
+    Printf(const char* format, const std::vector<Expression>& arguments)
+        : fmt(format)
+        , args(arguments){};
+
+    std::string render() const
+    {
+        auto fmt_render = std::string(fmt);
+        fmt_render      = "\"" + std::regex_replace(fmt_render, std::regex(R"(\n)"), "\\n") + "\"";
+
+        auto args_render = args;
+        args_render.insert(args_render.begin(), Literal(fmt_render));
+
+        return Call{"printf", args_render}.render();
+    }
+};
+
 // end of Statement class declarations
 
 static void operator+=(StatementList& stmts, const Statement& s)
@@ -1221,6 +1246,7 @@ struct BaseVisitor
     MAKE_VISITOR_OPERATOR(StatementList, IntrinsicStore);
     MAKE_VISITOR_OPERATOR(StatementList, IntrinsicStorePlanar);
     MAKE_VISITOR_OPERATOR(StatementList, IntrinsicLoadToDest);
+    MAKE_VISITOR_OPERATOR(StatementList, Printf);
 
     MAKE_VISITOR_OPERATOR(ArgumentList, ArgumentList);
 
@@ -1323,6 +1349,7 @@ struct BaseVisitor
     MAKE_TRIVIAL_STATEMENT_VISIT(SyncThreads)
     MAKE_TRIVIAL_STATEMENT_VISIT(Butterfly);
     MAKE_TRIVIAL_STATEMENT_VISIT(IntrinsicLoadToDest);
+    MAKE_TRIVIAL_STATEMENT_VISIT(Printf);
 
     MAKE_TRIVIAL_VISIT(Expression, Variable)
 


### PR DESCRIPTION
Add an explicit printf in the code generator. Although we can currently print values with existing constructs in the code gen, the new construct usage should be cleaner and more explicit than using the available methods.

I find it to be quite helpful for new kernel code development.

