### PR TITLE
Use MPI_Ialltoall where applicable to perform a global transpose

### DIFF
--- a/library/src/include/tree_node.h
+++ b/library/src/include/tree_node.h
@@ -1324,6 +1324,45 @@ struct CommAllToAllv : public MultiPlanItem
     }
 };
 
+// Whenever possible, rocFFT relies on MPI_Alltoall instead of MPI_Alltoallv,
+// since the former tends to be faster.
+struct CommAllToAll : public MultiPlanItem
+{
+    CommAllToAll() = default;
+
+    rocfft_precision  precision;
+    rocfft_array_type arrayType;
+
+    // counts per rank are the same for sender and receiver ranks
+    size_t count_per_rank;
+
+    // send/receive buffers
+    BufferPtr sendBuf;
+    BufferPtr recvBuf;
+
+    void ExecuteAsync(const rocfft_plan     plan,
+                      void*                 in_buffer[],
+                      void*                 out_buffer[],
+                      rocfft_execution_info info,
+                      size_t                multiPlanIdx) override;
+
+    void Wait() override;
+
+    void Print(rocfft_ostream& os, const int indent) const override;
+
+    bool WritesToBuffer(const BufferPtr& ptr) const override
+    {
+        // only writes to receive buffer
+        return ptr == recvBuf;
+    }
+
+    bool ExecutesOnRank(int comm_rank) const override
+    {
+        // runs on all ranks
+        return true;
+    }
+};
+
 // Tree-structured FFT plan.  This is specific to a single device on
 // a single rank, since the TreeNodes inside here will have device
 // memory allocated for things like kernel arguments and twiddles.

--- a/library/src/include/tree_node.h
+++ b/library/src/include/tree_node.h
@@ -759,7 +759,7 @@ public:
         : comm_rank(comm_rank)
     {
     }
-    InternalTempBuffer(const InternalTempBuffer&) = delete;
+    InternalTempBuffer(const InternalTempBuffer&)            = delete;
     InternalTempBuffer& operator=(const InternalTempBuffer&) = delete;
     ~InternalTempBuffer()                                    = default;
 
@@ -815,8 +815,8 @@ private:
 class BufferPtr
 {
 public:
-    BufferPtr()                 = default;
-    BufferPtr(const BufferPtr&) = default;
+    BufferPtr()                            = default;
+    BufferPtr(const BufferPtr&)            = default;
     BufferPtr& operator=(const BufferPtr&) = default;
     ~BufferPtr()                           = default;
 
@@ -943,7 +943,7 @@ struct MultiPlanItem
 {
     MultiPlanItem();
     virtual ~MultiPlanItem();
-    MultiPlanItem(const MultiPlanItem&) = delete;
+    MultiPlanItem(const MultiPlanItem&)            = delete;
     MultiPlanItem& operator=(const MultiPlanItem&) = delete;
 
     // multi-process requests
@@ -1284,9 +1284,11 @@ private:
 // Send data from all ranks to all ranks in the plan.  Each rank must
 // send from/to a single buffer (with different read/write offsets
 // for each other rank).
-struct CommAllToAllv : public MultiPlanItem
+// The all-to-all communication is performed using MPI_Ialltoall or MPI_Ialltoallv.
+// The former is preferable, as it is usually more optimized.
+struct CommAllToAll : public MultiPlanItem
 {
-    CommAllToAllv() = default;
+    CommAllToAll() = default;
 
     rocfft_precision  precision;
     rocfft_array_type arrayType;
@@ -1297,44 +1299,6 @@ struct CommAllToAllv : public MultiPlanItem
     std::vector<size_t> sendCounts;
     std::vector<size_t> recvOffsets;
     std::vector<size_t> recvCounts;
-
-    // send/receive buffers
-    BufferPtr sendBuf;
-    BufferPtr recvBuf;
-
-    void ExecuteAsync(const rocfft_plan     plan,
-                      void*                 in_buffer[],
-                      void*                 out_buffer[],
-                      rocfft_execution_info info,
-                      size_t                multiPlanIdx) override;
-    void Wait() override;
-
-    void Print(rocfft_ostream& os, const int indent) const override;
-
-    bool WritesToBuffer(const BufferPtr& ptr) const override
-    {
-        // only writes to receive buffer
-        return ptr == recvBuf;
-    }
-
-    bool ExecutesOnRank(int comm_rank) const override
-    {
-        // runs on all ranks
-        return true;
-    }
-};
-
-// Whenever possible, rocFFT relies on MPI_Alltoall instead of MPI_Alltoallv,
-// since the former tends to be faster.
-struct CommAllToAll : public MultiPlanItem
-{
-    CommAllToAll() = default;
-
-    rocfft_precision  precision;
-    rocfft_array_type arrayType;
-
-    // counts per rank are the same for sender and receiver ranks
-    size_t count_per_rank;
 
     // send/receive buffers
     BufferPtr sendBuf;

--- a/library/src/plan.cpp
+++ b/library/src/plan.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2016 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -2266,28 +2266,68 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
         }
     }
 
-    // add the all-to-all op itself, which depends on pack ops
-    auto alltoall_ptr                   = std::make_unique<CommAllToAllv>();
-    alltoall_ptr->precision             = precision;
-    alltoall_ptr->arrayType             = desc.inArrayType;
-    alltoall_ptr->sendOffsets           = send_offsets;
-    alltoall_ptr->sendCounts            = send_counts;
-    alltoall_ptr->recvOffsets           = recv_offsets;
-    alltoall_ptr->recvCounts            = recv_counts;
-    alltoall_ptr->sendBuf               = BufferPtr::temp(send_buf.data());
-    alltoall_ptr->recvBuf               = BufferPtr::temp(recv_buf.data());
-    auto alltoall_op                    = AddMultiPlanItem(std::move(alltoall_ptr), pack_ops);
-    multiPlan[alltoall_op]->group       = itemGroup;
-    multiPlan[alltoall_op]->description = "all-to-all communication";
-
-    // update the unpack ops to depend on the all-to-all
-    for(auto op : unpack_ops)
+    // check if communication layout allows to use All-to-All instead of All-to-All-v
+    bool   uniform_counts = true;
+    size_t expected_count = send_counts[0];
+    for(int i = 0; i < local_comm_size; ++i)
     {
-        AddAntecedent(op, alltoall_op);
+        if(send_counts[i] != expected_count || recv_counts[i] != expected_count)
+        {
+            uniform_counts = false;
+            break;
+        }
     }
 
-    // subsequent operations can depend on the unpack ops
-    outputItems = unpack_ops;
+    if(uniform_counts)
+    {
+        // Use CommAllToAll framework if send/recv counts are uniform
+        // across ranks
+        auto alltoall_ptr            = std::make_unique<CommAllToAll>();
+        alltoall_ptr->precision      = precision;
+        alltoall_ptr->arrayType      = desc.inArrayType;
+        alltoall_ptr->sendBuf        = BufferPtr::temp(send_buf.data());
+        alltoall_ptr->recvBuf        = BufferPtr::temp(recv_buf.data());
+        alltoall_ptr->count_per_rank = expected_count;
+
+        auto alltoall_op                    = AddMultiPlanItem(std::move(alltoall_ptr), pack_ops);
+        multiPlan[alltoall_op]->group       = itemGroup;
+        multiPlan[alltoall_op]->description = "all-to-all communication (MPI_Ialltoall)";
+
+        // update the unpack ops to depend on the all-to-all
+        for(auto op : unpack_ops)
+        {
+            AddAntecedent(op, alltoall_op);
+        }
+
+        outputItems = unpack_ops;
+    }
+    else
+    {
+        // fallback to CommAllToAllv
+        // add the all-to-all op itself, which depends on pack ops
+        auto alltoall_ptr         = std::make_unique<CommAllToAllv>();
+        alltoall_ptr->precision   = precision;
+        alltoall_ptr->arrayType   = desc.inArrayType;
+        alltoall_ptr->sendOffsets = send_offsets;
+        alltoall_ptr->sendCounts  = send_counts;
+        alltoall_ptr->recvOffsets = recv_offsets;
+        alltoall_ptr->recvCounts  = recv_counts;
+        alltoall_ptr->sendBuf     = BufferPtr::temp(send_buf.data());
+        alltoall_ptr->recvBuf     = BufferPtr::temp(recv_buf.data());
+
+        auto alltoall_op                    = AddMultiPlanItem(std::move(alltoall_ptr), pack_ops);
+        multiPlan[alltoall_op]->group       = itemGroup;
+        multiPlan[alltoall_op]->description = "all-to-all communication (MPI_Ialltoallv)";
+
+        // update the unpack ops to depend on the all-to-all
+        for(auto op : unpack_ops)
+        {
+            AddAntecedent(op, alltoall_op);
+        }
+
+        // subsequent operations can depend on the unpack ops
+        outputItems = unpack_ops;
+    }
 }
 
 bool rocfft_plan_t::BuildOptMultiDevicePlan()

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2020 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -979,6 +979,64 @@ void CommAllToAllv::Print(rocfft_ostream& os, const int indent) const
     printVec("sendCounts", sendCounts);
     printVec("recvOffsets", recvOffsets);
     printVec("recvCounts", recvCounts);
+}
+
+void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
+                                void*                 in_buffer[],
+                                void*                 out_buffer[],
+                                rocfft_execution_info info,
+                                size_t                multiPlanIdx)
+{
+    if(LOG_PLAN_ENABLED())
+    {
+        log_plan("MPI_Ialltoall\n");
+    }
+
+#ifdef ROCFFT_MPI_ENABLE
+
+    const auto elem_size        = element_size(precision, arrayType);
+    const auto comm             = plan->desc.mpi_comm;
+    int        send_count_bytes = 0;
+
+    if(count_per_rank * elem_size > static_cast<size_t>(std::numeric_limits<int>::max()))
+        throw std::runtime_error("MPI integer limit exceeded in CommAllToAll");
+
+    send_count_bytes = static_cast<int>(count_per_rank * elem_size);
+
+    MPI_Request request;
+    const auto  mpiret = MPI_Ialltoall(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
+                                      send_count_bytes,
+                                      MPI_CHAR,
+                                      recvBuf.get(in_buffer, out_buffer, local_comm_rank),
+                                      send_count_bytes,
+                                      MPI_CHAR,
+                                      comm,
+                                      &request);
+
+    if(mpiret != MPI_SUCCESS)
+        throw std::runtime_error("MPI_Ialltoall failed: " + std::to_string(mpiret));
+
+    comm_requests.push_back(request);
+
+#else
+    throw std::runtime_error("CommAllToAll not implemented");
+#endif
+}
+
+void CommAllToAll::Wait()
+{
+    WaitCommRequests();
+}
+
+void CommAllToAll::Print(rocfft_ostream& os, const int indent) const
+{
+    std::string indentStr;
+    int         i = indent;
+    while(i--)
+        indentStr += "    ";
+
+    os << indentStr << "CommAllToAll " << precision_name(precision) << " "
+       << PrintArrayType(arrayType) << ": count_per_rank = " << count_per_rank << "\n";
 }
 
 void ExecPlan::Print(rocfft_ostream& os, const int indent) const


### PR DESCRIPTION
Currently, the global transpose operation uses `Alltoallv` communication by default. However, `Alltoall` is generally faster and more efficient across various MPI distributions. In this PR, we propose using all-to-all communication wherever possible, and falling back to `Alltoallv` when necessary.