### PR TITLE
Perform global transpose using all-to-all whenever possible

### DIFF
--- a/library/src/include/tree_node.h
+++ b/library/src/include/tree_node.h
@@ -1288,21 +1288,37 @@ private:
 // The former is preferable, as it is usually more optimized.
 struct CommAllToAll : public MultiPlanItem
 {
-    CommAllToAll() = default;
+    CommAllToAll(rocfft_precision           _precision,
+                 rocfft_array_type          _arrayType,
+                 const std::vector<size_t>& _sendOffsets,
+                 const std::vector<size_t>& _sendCounts,
+                 const std::vector<size_t>& _recvOffsets,
+                 const std::vector<size_t>& _recvCounts,
+                 BufferPtr                  _sendBuf,
+                 BufferPtr                  _recvBuf)
+        : precision(_precision)
+        , arrayType(_arrayType)
+        , sendOffsets(_sendOffsets)
+        , sendCounts(_sendCounts)
+        , recvOffsets(_recvOffsets)
+        , recvCounts(_recvCounts)
+        , sendBuf(_sendBuf)
+        , recvBuf(_recvBuf)
+    {
+        // Currently MPI interface uses 32-bit signed ints, so assert
+        // that our counts/offsets don't overflow that type
+        auto checkArray = [](const std::vector<size_t>& arr) {
+            if(std::any_of(arr.begin(), arr.end(), [](size_t elem) {
+                   return elem > std::numeric_limits<int>::max();
+               }))
+                throw std::runtime_error("count/offset exceeds int max");
+        };
 
-    rocfft_precision  precision;
-    rocfft_array_type arrayType;
-
-    // counts and offsets are all in elements (where element size is
-    // knowable from precision + array type), for the current rank
-    std::vector<size_t> sendOffsets;
-    std::vector<size_t> sendCounts;
-    std::vector<size_t> recvOffsets;
-    std::vector<size_t> recvCounts;
-
-    // send/receive buffers
-    BufferPtr sendBuf;
-    BufferPtr recvBuf;
+        checkArray(sendOffsets);
+        checkArray(sendCounts);
+        checkArray(recvOffsets);
+        checkArray(recvCounts);
+    }
 
     // enum for error handling for different multi-process communication
     // libraries such as MPI, RCCL, rocSHMEM, etc.
@@ -1335,6 +1351,21 @@ struct CommAllToAll : public MultiPlanItem
         // runs on all ranks
         return true;
     }
+
+private:
+    rocfft_precision  precision;
+    rocfft_array_type arrayType;
+
+    // counts and offsets are all in elements (where element size is
+    // knowable from precision + array type), for the current rank
+    std::vector<size_t> sendOffsets;
+    std::vector<size_t> sendCounts;
+    std::vector<size_t> recvOffsets;
+    std::vector<size_t> recvCounts;
+
+    // send/receive buffers
+    BufferPtr sendBuf;
+    BufferPtr recvBuf;
 };
 
 // Tree-structured FFT plan.  This is specific to a single device on

--- a/library/src/include/tree_node.h
+++ b/library/src/include/tree_node.h
@@ -1284,9 +1284,11 @@ private:
 // Send data from all ranks to all ranks in the plan.  Each rank must
 // send from/to a single buffer (with different read/write offsets
 // for each other rank).
-struct CommAllToAllv : public MultiPlanItem
+// The all-to-all communication is performed using MPI_Ialltoall or MPI_Ialltoallv.
+// The former is preferable, as it is usually more optimized.
+struct CommAllToAll : public MultiPlanItem
 {
-    CommAllToAllv() = default;
+    CommAllToAll() = default;
 
     rocfft_precision  precision;
     rocfft_array_type arrayType;
@@ -1307,6 +1309,7 @@ struct CommAllToAllv : public MultiPlanItem
                       void*                 out_buffer[],
                       rocfft_execution_info info,
                       size_t                multiPlanIdx) override;
+
     void Wait() override;
 
     void Print(rocfft_ostream& os, const int indent) const override;

--- a/library/src/include/tree_node.h
+++ b/library/src/include/tree_node.h
@@ -1061,19 +1061,19 @@ struct CommPointToPoint : public MultiPlanItem
     }
 
 private:
-    rocfft_precision  precision;
-    rocfft_array_type arrayType;
+    const rocfft_precision  precision;
+    const rocfft_array_type arrayType;
 
     // number of elements to copy
-    size_t numElems;
+    const size_t numElems;
 
-    rocfft_location_t srcLocation;
-    BufferPtr         srcPtr;
-    size_t            srcOffset = 0;
+    const rocfft_location_t srcLocation;
+    const BufferPtr         srcPtr;
+    const size_t            srcOffset = 0;
 
-    rocfft_location_t destLocation;
-    BufferPtr         destPtr;
-    size_t            destOffset = 0;
+    const rocfft_location_t destLocation;
+    const BufferPtr         destPtr;
+    const size_t            destOffset = 0;
     // Stream to run the async operation in
     hipStream_wrapper_t stream;
     // Event to signal when the async operations are finished.
@@ -1166,10 +1166,10 @@ struct CommScatter : public MultiPlanItem
     }
 
 private:
-    rocfft_precision  precision;
-    rocfft_array_type arrayType;
-    rocfft_location_t srcLocation;
-    BufferPtr         srcPtr;
+    const rocfft_precision  precision;
+    const rocfft_array_type arrayType;
+    const rocfft_location_t srcLocation;
+    const BufferPtr         srcPtr;
 
     std::vector<ScatterOp> ops;
 
@@ -1265,11 +1265,11 @@ struct CommGather : public MultiPlanItem
     }
 
 private:
-    rocfft_precision  precision;
-    rocfft_array_type arrayType;
+    const rocfft_precision  precision;
+    const rocfft_array_type arrayType;
 
-    rocfft_location_t destLocation;
-    BufferPtr         destPtr;
+    const rocfft_location_t destLocation;
+    const BufferPtr         destPtr;
 
     std::vector<GatherOp> ops;
 
@@ -1353,19 +1353,19 @@ struct CommAllToAll : public MultiPlanItem
     }
 
 private:
-    rocfft_precision  precision;
-    rocfft_array_type arrayType;
+    const rocfft_precision  precision;
+    const rocfft_array_type arrayType;
 
     // counts and offsets are all in elements (where element size is
     // knowable from precision + array type), for the current rank
-    std::vector<size_t> sendOffsets;
-    std::vector<size_t> sendCounts;
-    std::vector<size_t> recvOffsets;
-    std::vector<size_t> recvCounts;
+    const std::vector<size_t> sendOffsets;
+    const std::vector<size_t> sendCounts;
+    const std::vector<size_t> recvOffsets;
+    const std::vector<size_t> recvCounts;
 
     // send/receive buffers
-    BufferPtr sendBuf;
-    BufferPtr recvBuf;
+    const BufferPtr sendBuf;
+    const BufferPtr recvBuf;
 };
 
 // Tree-structured FFT plan.  This is specific to a single device on

--- a/library/src/include/tree_node.h
+++ b/library/src/include/tree_node.h
@@ -1304,6 +1304,16 @@ struct CommAllToAll : public MultiPlanItem
     BufferPtr sendBuf;
     BufferPtr recvBuf;
 
+    // enum for error handling for different multi-process communication
+    // libraries such as MPI, RCCL, rocSHMEM, etc.
+    enum CommStatus
+    {
+        COMM_SUCCESS,
+        COMM_MPI_ERROR
+    };
+    CommStatus  comm_status = COMM_SUCCESS;
+    std::string error_message;
+
     void ExecuteAsync(const rocfft_plan     plan,
                       void*                 in_buffer[],
                       void*                 out_buffer[],

--- a/library/src/plan.cpp
+++ b/library/src/plan.cpp
@@ -1979,13 +1979,13 @@ void rocfft_plan_t::GlobalTranspose(size_t                     elem_size,
                                     std::vector<size_t>&       outputItems,
                                     size_t                     transposeNumber)
 {
-    // All-to-all transpose is preferred as it's faster.  But we use
-    // MPI Alltoallv, which requires that each rank have a single base
-    // pointer to send/receive with offsets for every other rank.
+    // All-to-all transpose is preferred as it's faster. This requires
+    // that each rank have a single base pointer to send/receive with
+    // offsets for every other rank.
     // That's only feasible if each rank has data on just one device
     // (since we can hipMalloc a single buffer per device and have
     // offsets into it).
-    //
+
     // Fall back to point-to-point transfers if all-to-all is not
     // possible.
     std::string itemGroup = "transpose_" + std::to_string(transposeNumber);
@@ -1997,6 +1997,8 @@ void rocfft_plan_t::GlobalTranspose(size_t                     elem_size,
     }
     else
     {
+        // GlobalTransposeA2A will use MPI_Ialltoall when possible,
+        // falling back to MPI_Ialltoallv otherwise.
         GlobalTransposeA2A(
             elem_size, inField, outField, input, output, inputAntecedents, outputItems, itemGroup);
     }

--- a/library/src/plan.cpp
+++ b/library/src/plan.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2016 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -2267,7 +2267,7 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
     }
 
     // add the all-to-all op itself, which depends on pack ops
-    auto alltoall_ptr                   = std::make_unique<CommAllToAllv>();
+    auto alltoall_ptr                   = std::make_unique<CommAllToAll>();
     alltoall_ptr->precision             = precision;
     alltoall_ptr->arrayType             = desc.inArrayType;
     alltoall_ptr->sendOffsets           = send_offsets;

--- a/library/src/plan.cpp
+++ b/library/src/plan.cpp
@@ -2269,15 +2269,14 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
     }
 
     // add the all-to-all op itself, which depends on pack ops
-    auto alltoall_ptr                   = std::make_unique<CommAllToAll>();
-    alltoall_ptr->precision             = precision;
-    alltoall_ptr->arrayType             = desc.inArrayType;
-    alltoall_ptr->sendOffsets           = send_offsets;
-    alltoall_ptr->sendCounts            = send_counts;
-    alltoall_ptr->recvOffsets           = recv_offsets;
-    alltoall_ptr->recvCounts            = recv_counts;
-    alltoall_ptr->sendBuf               = BufferPtr::temp(send_buf.data());
-    alltoall_ptr->recvBuf               = BufferPtr::temp(recv_buf.data());
+    auto alltoall_ptr                   = std::make_unique<CommAllToAll>(precision,
+                                                       desc.inArrayType,
+                                                       send_offsets,
+                                                       send_counts,
+                                                       recv_offsets,
+                                                       recv_counts,
+                                                       BufferPtr::temp(send_buf.data()),
+                                                       BufferPtr::temp(recv_buf.data()));
     auto alltoall_op                    = AddMultiPlanItem(std::move(alltoall_ptr), pack_ops);
     multiPlan[alltoall_op]->group       = itemGroup;
     multiPlan[alltoall_op]->description = "all-to-all communication";

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -918,16 +918,9 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
     const auto elem_size = element_size(precision, arrayType);
 
     // check if uniform counts
-    bool   uniform_counts = true;
-    size_t expected_count = sendCounts[0];
-    for(size_t i = 0; i < num_ranks; ++i)
-    {
-        if(sendCounts[i] != expected_count || recvCounts[i] != expected_count)
-        {
-            uniform_counts = false;
-            break;
-        }
-    }
+    auto count_matches_first = [&](size_t count) { return count == sendCounts[0]; };
+    bool uniform_counts = std::all_of(sendCounts.begin(), sendCounts.end(), count_matches_first)
+                          || std::all_of(recvCounts.begin(), recvCounts.end(), count_matches_first);
 
     MPI_Request request;
 
@@ -936,11 +929,11 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
         if(LOG_PLAN_ENABLED())
             log_plan("Using MPI_Ialltoall\n");
 
-        if(expected_count * elem_size > static_cast<size_t>(std::numeric_limits<int>::max()))
+        if(sendCounts[0] * elem_size > static_cast<size_t>(std::numeric_limits<int>::max()))
             throw std::runtime_error(
                 "CommAllToAll: element size * count_per_rank exceeds MPI_INT limit");
 
-        const int send_count_bytes = static_cast<int>(expected_count * elem_size);
+        const int send_count_bytes = static_cast<int>(sendCounts[0] * elem_size);
 
         const auto mpiret = MPI_Ialltoall(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
                                           send_count_bytes,
@@ -1021,19 +1014,9 @@ void CommAllToAll::Print(rocfft_ostream& os, const int indent) const
     };
 
     // determine whether counts are uniform
-    bool uniform_counts = true;
-    if(!sendCounts.empty())
-    {
-        const size_t expected = sendCounts[0];
-        for(const auto& count : sendCounts)
-        {
-            if(count != expected)
-            {
-                uniform_counts = false;
-                break;
-            }
-        }
-    }
+    auto count_matches_first = [&](size_t count) { return count == sendCounts[0]; };
+    bool uniform_counts = std::all_of(sendCounts.begin(), sendCounts.end(), count_matches_first)
+                          || std::all_of(recvCounts.begin(), recvCounts.end(), count_matches_first);
 
     os << indentStr << "CommAllToAll " << precision_name(precision) << " "
        << PrintArrayType(arrayType) << (uniform_counts ? " (MPI_Ialltoall)" : " (MPI_alltoallv)")

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -1038,7 +1038,7 @@ void CommAllToAll::Print(rocfft_ostream& os, const int indent) const
                           && std::all_of(recvCounts.begin(), recvCounts.end(), count_matches_first);
 
     os << indentStr << "CommAllToAll " << precision_name(precision) << " "
-       << PrintArrayType(arrayType) << (uniform_counts ? " (MPI_Ialltoall)" : " (MPI_alltoallv)")
+       << PrintArrayType(arrayType) << (uniform_counts ? " (MPI_Ialltoall)" : " (MPI_Ialltoallv)")
        << ":\n";
 
     if(uniform_counts)

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -929,11 +929,13 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
         if(LOG_PLAN_ENABLED())
             log_plan("Using MPI_Ialltoall\n");
 
+        // guard against overflow of MPI_INT
         if(sendCounts[0] * elem_size > static_cast<size_t>(std::numeric_limits<int>::max()))
         {
-            std::cerr << "Rank " << local_comm_rank
-                      << ": element size * count_per_rank exceeds MPI_INT limit\n";
-            MPI_Abort(plan->desc.mpi_comm, 1);
+            comm_status   = COMM_MPI_ERROR;
+            error_message = "Rank " + std::to_string(local_comm_rank)
+                            + ": element size * count_per_rank exceeds MPI_INT limit";
+            return;
         }
 
         const int send_count_bytes = static_cast<int>(sendCounts[0] * elem_size);
@@ -949,30 +951,41 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
 
         if(mpiret != MPI_SUCCESS)
         {
-            std::cerr << "MPI_Ialltoall failed on rank " << local_comm_rank
-                      << " with error: " << mpiret << std::endl;
-            MPI_Abort(plan->desc.mpi_comm, mpiret);
+            char errmsg[MPI_MAX_ERROR_STRING];
+            int  errlen = 0;
+            MPI_Error_string(mpiret, errmsg, &errlen);
+
+            comm_status   = COMM_MPI_ERROR;
+            error_message = "MPI_Ialltoall failed on rank " + std::to_string(local_comm_rank) + ": "
+                            + std::string(errmsg);
+
+            return;
         }
     }
     else
     {
-
         if(LOG_PLAN_ENABLED())
             log_plan("Using MPI_Ialltoallv\n");
 
+        const int local_comm_rank = plan->get_local_comm_rank();
+
         // MPI takes ints for everything, convert our size_t elements to int bytes
-        auto convertToInt = [&, plan](const std::vector<size_t>& src, std::vector<int>& dest) {
-            dest.reserve(src.size());
-            for(auto i : src)
-            {
-                if(i > std::numeric_limits<int>::max())
-                {
-                    std::cerr << ": MPI integer limit exceeded (value = " << i << ")\n";
-                    MPI_Abort(plan->desc.mpi_comm, 2);
-                }
-                dest.push_back(i);
-            }
-        };
+        auto convertToInt
+            = [&, local_comm_rank](const std::vector<size_t>& src, std::vector<int>& dest) {
+                  dest.reserve(src.size());
+                  for(auto i : src)
+                  {
+                      if(i > std::numeric_limits<int>::max())
+                      {
+                          comm_status   = COMM_MPI_ERROR;
+                          error_message = "Rank " + std::to_string(local_comm_rank)
+                                          + ": MPI integer limit exceeded (value = "
+                                          + std::to_string(i) + ")";
+                          return;
+                      }
+                      dest.push_back(static_cast<int>(i));
+                  }
+              };
 
         std::vector<int> intSendOffsets;
         std::vector<int> intSendCounts;
@@ -996,9 +1009,15 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
 
         if(mpiret != MPI_SUCCESS)
         {
-            std::cerr << "MPI_Ialltoallv failed on rank " << local_comm_rank
-                      << " with error: " << mpiret << std::endl;
-            MPI_Abort(plan->desc.mpi_comm, mpiret);
+            char errmsg[MPI_MAX_ERROR_STRING];
+            int  errlen = 0;
+            MPI_Error_string(mpiret, errmsg, &errlen);
+
+            comm_status   = COMM_MPI_ERROR;
+            error_message = "MPI_Ialltoallv failed on rank " + std::to_string(local_comm_rank)
+                            + ": " + std::string(errmsg);
+
+            return;
         }
     }
 
@@ -1012,6 +1031,12 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
 void CommAllToAll::Wait()
 {
     WaitCommRequests();
+
+    if(comm_status == COMM_MPI_ERROR)
+    {
+        // Now it's safe to throw or return error
+        throw std::runtime_error(error_message);
+    }
 }
 
 void CommAllToAll::Print(rocfft_ostream& os, const int indent) const

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -929,15 +929,6 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
         if(LOG_PLAN_ENABLED())
             log_plan("Using MPI_Ialltoall\n");
 
-        // guard against overflow of MPI_INT
-        if(sendCounts[0] * elem_size > static_cast<size_t>(std::numeric_limits<int>::max()))
-        {
-            comm_status   = COMM_MPI_ERROR;
-            error_message = "Rank " + std::to_string(local_comm_rank)
-                            + ": element size * count_per_rank exceeds MPI_INT limit";
-            return;
-        }
-
         const int send_count_bytes = static_cast<int>(sendCounts[0] * elem_size);
 
         const auto mpiret = MPI_Ialltoall(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
@@ -970,22 +961,10 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
         const int local_comm_rank = plan->get_local_comm_rank();
 
         // MPI takes ints for everything, convert our size_t elements to int bytes
-        auto convertToInt
-            = [&, local_comm_rank](const std::vector<size_t>& src, std::vector<int>& dest) {
-                  dest.reserve(src.size());
-                  for(auto i : src)
-                  {
-                      if(i > std::numeric_limits<int>::max())
-                      {
-                          comm_status   = COMM_MPI_ERROR;
-                          error_message = "Rank " + std::to_string(local_comm_rank)
-                                          + ": MPI integer limit exceeded (value = "
-                                          + std::to_string(i) + ")";
-                          return;
-                      }
-                      dest.push_back(static_cast<int>(i));
-                  }
-              };
+        auto convertToInt = [](const std::vector<size_t>& src, std::vector<int>& dest) {
+            dest.reserve(src.size());
+            std::copy(src.begin(), src.end(), std::back_inserter(dest));
+        };
 
         std::vector<int> intSendOffsets;
         std::vector<int> intSendCounts;

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -1056,7 +1056,7 @@ void CommAllToAll::Print(rocfft_ostream& os, const int indent) const
     // determine whether counts are uniform
     auto count_matches_first = [&](size_t count) { return count == sendCounts[0]; };
     bool uniform_counts = std::all_of(sendCounts.begin(), sendCounts.end(), count_matches_first)
-                          || std::all_of(recvCounts.begin(), recvCounts.end(), count_matches_first);
+                          && std::all_of(recvCounts.begin(), recvCounts.end(), count_matches_first);
 
     os << indentStr << "CommAllToAll " << precision_name(precision) << " "
        << PrintArrayType(arrayType) << (uniform_counts ? " (MPI_Ialltoall)" : " (MPI_alltoallv)")

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -920,7 +920,7 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
     // check if uniform counts
     auto count_matches_first = [&](size_t count) { return count == sendCounts[0]; };
     bool uniform_counts = std::all_of(sendCounts.begin(), sendCounts.end(), count_matches_first)
-                          || std::all_of(recvCounts.begin(), recvCounts.end(), count_matches_first);
+                          && std::all_of(recvCounts.begin(), recvCounts.end(), count_matches_first);
 
     MPI_Request request;
 
@@ -930,8 +930,11 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
             log_plan("Using MPI_Ialltoall\n");
 
         if(sendCounts[0] * elem_size > static_cast<size_t>(std::numeric_limits<int>::max()))
-            throw std::runtime_error(
-                "CommAllToAll: element size * count_per_rank exceeds MPI_INT limit");
+        {
+            std::cerr << "Rank " << local_comm_rank
+                      << ": element size * count_per_rank exceeds MPI_INT limit\n";
+            MPI_Abort(plan->desc.mpi_comm, 1);
+        }
 
         const int send_count_bytes = static_cast<int>(sendCounts[0] * elem_size);
 
@@ -945,7 +948,11 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
                                           &request);
 
         if(mpiret != MPI_SUCCESS)
-            throw std::runtime_error("MPI_Ialltoall failed: " + std::to_string(mpiret));
+        {
+            std::cerr << "MPI_Ialltoall failed on rank " << local_comm_rank
+                      << " with error: " << mpiret << std::endl;
+            MPI_Abort(plan->desc.mpi_comm, mpiret);
+        }
     }
     else
     {
@@ -954,12 +961,15 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
             log_plan("Using MPI_Ialltoallv\n");
 
         // MPI takes ints for everything, convert our size_t elements to int bytes
-        auto convertToInt = [](const std::vector<size_t>& src, std::vector<int>& dest) {
+        auto convertToInt = [&, plan](const std::vector<size_t>& src, std::vector<int>& dest) {
             dest.reserve(src.size());
             for(auto i : src)
             {
                 if(i > std::numeric_limits<int>::max())
-                    throw std::runtime_error("MPI integer limit exceeded");
+                {
+                    std::cerr << ": MPI integer limit exceeded (value = " << i << ")\n";
+                    MPI_Abort(plan->desc.mpi_comm, 2);
+                }
                 dest.push_back(i);
             }
         };
@@ -983,8 +993,13 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
                                            rocfft_type_to_mpi_type(precision, arrayType),
                                            plan->desc.mpi_comm,
                                            &request);
+
         if(mpiret != MPI_SUCCESS)
-            throw std::runtime_error("MPI_Ialltoallv failed: " + std::to_string(mpiret));
+        {
+            std::cerr << "MPI_Ialltoallv failed on rank " << local_comm_rank
+                      << " with error: " << mpiret << std::endl;
+            MPI_Abort(plan->desc.mpi_comm, mpiret);
+        }
     }
 
     comm_requests.push_back(request);

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2020 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -894,11 +894,11 @@ void CommGather::Print(rocfft_ostream& os, const int indent) const
     }
 }
 
-void CommAllToAllv::ExecuteAsync(const rocfft_plan     plan,
-                                 void*                 in_buffer[],
-                                 void*                 out_buffer[],
-                                 rocfft_execution_info info,
-                                 size_t                multiPlanIdx)
+void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
+                                void*                 in_buffer[],
+                                void*                 out_buffer[],
+                                rocfft_execution_info info,
+                                size_t                multiPlanIdx)
 {
     // check that we have as many elems in our count/offset buffers as
     // we have ranks
@@ -906,60 +906,108 @@ void CommAllToAllv::ExecuteAsync(const rocfft_plan     plan,
     if(sendOffsets.size() != num_ranks || sendCounts.size() != num_ranks
        || recvOffsets.size() != num_ranks || recvCounts.size() != num_ranks)
         throw std::runtime_error(
-            "CommAllToAllv: number of counts/offsets does not match number of ranks");
+            "CommAllToAll: number of counts/offsets does not match number of ranks");
 
     if(LOG_PLAN_ENABLED())
     {
-        log_plan("MPI_Ialltoallv\n");
+        log_plan("CommAllToAll: deciding between MPI_Ialltoall and MPI_Ialltoallv\n");
     }
 
 #ifdef ROCFFT_MPI_ENABLE
 
-    // MPI takes ints for everything, convert our size_t elements to int bytes
-    auto convertToInt = [](const std::vector<size_t>& src, std::vector<int>& dest) {
-        dest.reserve(src.size());
-        for(auto i : src)
-        {
-            if(i > std::numeric_limits<int>::max())
-                throw std::runtime_error("MPI integer limit exceeded");
-            dest.push_back(i);
-        }
-    };
+    const auto elem_size = element_size(precision, arrayType);
 
-    std::vector<int> intSendOffsets;
-    std::vector<int> intSendCounts;
-    std::vector<int> intRecvOffsets;
-    std::vector<int> intRecvCounts;
-    convertToInt(sendOffsets, intSendOffsets);
-    convertToInt(sendCounts, intSendCounts);
-    convertToInt(recvOffsets, intRecvOffsets);
-    convertToInt(recvCounts, intRecvCounts);
+    // check if uniform counts
+    bool   uniform_counts = true;
+    size_t expected_count = sendCounts[0];
+    for(size_t i = 0; i < num_ranks; ++i)
+    {
+        if(sendCounts[i] != expected_count || recvCounts[i] != expected_count)
+        {
+            uniform_counts = false;
+            break;
+        }
+    }
 
     MPI_Request request;
-    const auto  mpiret = MPI_Ialltoallv(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
-                                       intSendCounts.data(),
-                                       intSendOffsets.data(),
-                                       rocfft_type_to_mpi_type(precision, arrayType),
-                                       recvBuf.get(in_buffer, out_buffer, local_comm_rank),
-                                       intRecvCounts.data(),
-                                       intRecvOffsets.data(),
-                                       rocfft_type_to_mpi_type(precision, arrayType),
-                                       plan->desc.mpi_comm,
-                                       &request);
-    if(mpiret != MPI_SUCCESS)
-        throw std::runtime_error("MPI_Ialltoallv failed: " + std::to_string(mpiret));
+
+    if(uniform_counts)
+    {
+        if(LOG_PLAN_ENABLED())
+            log_plan("Using MPI_Ialltoall\n");
+
+        if(expected_count * elem_size > static_cast<size_t>(std::numeric_limits<int>::max()))
+            throw std::runtime_error(
+                "CommAllToAll: element size * count_per_rank exceeds MPI_INT limit");
+
+        const int send_count_bytes = static_cast<int>(expected_count * elem_size);
+
+        const auto mpiret = MPI_Ialltoall(
+            sendBuf.get(in_buffer, out_buffer, get_local_comm_rank()),
+            send_count_bytes,
+            MPI_CHAR,
+            recvBuf.get(in_buffer, out_buffer, get_local_comm_rank()),
+            `,
+            MPI_CHAR,
+            plan->desc.mpi_comm,
+            &request);
+
+        if(mpiret != MPI_SUCCESS)
+            throw std::runtime_error("MPI_Ialltoall failed: " + std::to_string(mpiret));
+    }
+    else
+    {
+
+        if(LOG_PLAN_ENABLED())
+            log_plan("Using MPI_Ialltoallv\n");
+
+        // MPI takes ints for everything, convert our size_t elements to int bytes
+        auto convertToInt = [](const std::vector<size_t>& src, std::vector<int>& dest) {
+            dest.reserve(src.size());
+            for(auto i : src)
+            {
+                if(i > std::numeric_limits<int>::max())
+                    throw std::runtime_error("MPI integer limit exceeded");
+                dest.push_back(i);
+            }
+        };
+
+        std::vector<int> intSendOffsets;
+        std::vector<int> intSendCounts;
+        std::vector<int> intRecvOffsets;
+        std::vector<int> intRecvCounts;
+        convertToInt(sendOffsets, intSendOffsets);
+        convertToInt(sendCounts, intSendCounts);
+        convertToInt(recvOffsets, intRecvOffsets);
+        convertToInt(recvCounts, intRecvCounts);
+
+        const auto mpiret = MPI_Ialltoallv(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
+                                           intSendCounts.data(),
+                                           intSendOffsets.data(),
+                                           rocfft_type_to_mpi_type(precision, arrayType),
+                                           recvBuf.get(in_buffer, out_buffer, local_comm_rank),
+                                           intRecvCounts.data(),
+                                           intRecvOffsets.data(),
+                                           rocfft_type_to_mpi_type(precision, arrayType),
+                                           plan->desc.mpi_comm,
+                                           &request);
+        if(mpiret != MPI_SUCCESS)
+            throw std::runtime_error("MPI_Ialltoallv failed: " + std::to_string(mpiret));
+    }
+
     comm_requests.push_back(request);
+
 #else
-    throw std::runtime_error("CommAllToAllv not implemented");
+    throw std::runtime_error("CommAllToAll not implemented");
 #endif
 }
 
-void CommAllToAllv::Wait()
+void CommAllToAll::Wait()
 {
     WaitCommRequests();
 }
 
-void CommAllToAllv::Print(rocfft_ostream& os, const int indent) const
+void CommAllToAll::Print(rocfft_ostream& os, const int indent) const
 {
     std::string indentStr;
     int         i = indent;
@@ -973,12 +1021,38 @@ void CommAllToAllv::Print(rocfft_ostream& os, const int indent) const
         os << "\n";
     };
 
-    os << indentStr << "CommAllToAllv " << precision_name(precision) << " "
-       << PrintArrayType(arrayType) << ":\n";
-    printVec("sendOffsets", sendOffsets);
-    printVec("sendCounts", sendCounts);
-    printVec("recvOffsets", recvOffsets);
-    printVec("recvCounts", recvCounts);
+    // determine whether counts are uniform
+    bool uniform_counts = true;
+    if(!sendCounts.empty())
+    {
+        const size_t expected = sendCounts[0];
+        for(const auto& count : sendCounts)
+        {
+            if(count != expected)
+            {
+                uniform_counts = false;
+                break;
+            }
+        }
+    }
+
+    os << indentStr << "CommAllToAll " << precision_name(precision) << " "
+       << PrintArrayType(arrayType) << (uniform_counts ? " (MPI_Ialltoall)" : " (MPI_alltoallv)")
+       << ":\n";
+
+    if(uniform_counts)
+    {
+        // alltoall: just print the count once
+        os << indentStr << " count_per_rank: " << sendCounts[0] << "\n";
+    }
+    else
+    {
+        // alltoallv: print full arrays
+        printVec("sendOffsets", sendOffsets);
+        printVec("sendCounts", sendCounts);
+        printVec("recvOffsets", recvOffsets);
+        printVec("recvCounts", recvCounts);
+    }
 }
 
 void ExecPlan::Print(rocfft_ostream& os, const int indent) const

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -943,11 +943,11 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
         const int send_count_bytes = static_cast<int>(expected_count * elem_size);
 
         const auto mpiret = MPI_Ialltoall(
-            sendBuf.get(in_buffer, out_buffer, get_local_comm_rank()),
+            sendBuf.get(in_buffer, out_buffer, local_comm_rank),
             send_count_bytes,
             MPI_CHAR,
-            recvBuf.get(in_buffer, out_buffer, get_local_comm_rank()),
-            `,
+            recvBuf.get(in_buffer, out_buffer, local_comm_rank),
+            send_count_bytes,
             MPI_CHAR,
             plan->desc.mpi_comm,
             &request);

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -942,15 +942,14 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
 
         const int send_count_bytes = static_cast<int>(expected_count * elem_size);
 
-        const auto mpiret = MPI_Ialltoall(
-            sendBuf.get(in_buffer, out_buffer, local_comm_rank),
-            send_count_bytes,
-            MPI_CHAR,
-            recvBuf.get(in_buffer, out_buffer, local_comm_rank),
-            send_count_bytes,
-            MPI_CHAR,
-            plan->desc.mpi_comm,
-            &request);
+        const auto mpiret = MPI_Ialltoall(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
+                                          send_count_bytes,
+                                          MPI_CHAR,
+                                          recvBuf.get(in_buffer, out_buffer, local_comm_rank),
+                                          send_count_bytes,
+                                          MPI_CHAR,
+                                          plan->desc.mpi_comm,
+                                          &request);
 
         if(mpiret != MPI_SUCCESS)
             throw std::runtime_error("MPI_Ialltoall failed: " + std::to_string(mpiret));


### PR DESCRIPTION
Currently, the global transpose operation uses `Alltoallv` communication by default. However, `Alltoall` is generally faster and more efficient across various MPI distributions. In this PR, we propose using all-to-all communication wherever possible, and falling back to `Alltoallv` when necessary.