### PR TITLE
generator: store LDS size with each kernel config

### DIFF
--- a/library/src/device/generator.py
+++ b/library/src/device/generator.py
@@ -811,13 +811,10 @@ class Map(BaseNodeOps):
             Throw('std::runtime_error("' + str(what_error) + '")'))
         return If(Equal(status, "false"), throw)
 
-    def assert_insert(self, key, value, def_key_pool, function_map):
-        insert = Call('insert_default_entry',
-                      arguments=ArgumentList(key, value, def_key_pool,
-                                             function_map)).inline()
-        throw = StatementList(Throw('std::runtime_error("' + str(key) + '")'))
-        return If(Equal(insert, "false"), throw)
-
+    def assert_insert(self, key, value, def_key_pool, function_map, lds_size_bytes):
+        return Call('insert_default_entry',
+                    arguments=ArgumentList(key, value, def_key_pool,
+                                           function_map, lds_size_bytes))
     # def __getitem__(self, idx):
     #     return ArrayElement(self.name, idx)
 

--- a/library/src/device/generator.py
+++ b/library/src/device/generator.py
@@ -811,10 +811,12 @@ class Map(BaseNodeOps):
             Throw('std::runtime_error("' + str(what_error) + '")'))
         return If(Equal(status, "false"), throw)
 
-    def assert_insert(self, key, value, def_key_pool, function_map, lds_size_bytes):
+    def assert_insert(self, key, value, def_key_pool, function_map,
+                      lds_size_bytes):
         return Call('insert_default_entry',
                     arguments=ArgumentList(key, value, def_key_pool,
                                            function_map, lds_size_bytes))
+
     # def __getitem__(self, idx):
     #     return ArrayElement(self.name, idx)
 

--- a/library/src/device/generator/stockham_gen.cpp
+++ b/library/src/device/generator/stockham_gen.cpp
@@ -271,6 +271,7 @@ int main()
     bool         direct_to_from_reg;
     bool         half_lds;
     unsigned int workgroup_size;
+    unsigned int lds_size_bytes;
 
     const char* DELIM = "";
     std::cout << "{";
@@ -289,6 +290,9 @@ int main()
 
         // work backwards from the end
         auto arg = tokens.rbegin();
+
+        lds_size_bytes = std::stoul(*arg);
+        ++arg;
 
         std::string kernel_name = *arg;
 
@@ -333,6 +337,10 @@ int main()
         StockhamGeneratorSpecs specs2d(factors2d, factors, precisions, workgroup_size, scheme);
         if(!threads_per_transform.empty())
             specs2d.threads_per_transform = threads_per_transform.back();
+
+        // aim for occupancy-2 by default
+        specs.lds_byte_limit   = lds_size_bytes / 2;
+        specs2d.lds_byte_limit = lds_size_bytes / 2;
 
         // create spec and pass to stockham_variants, writes partial output to stdout
         std::cout << DELIM;

--- a/library/src/device/kernel-generator.py
+++ b/library/src/device/kernel-generator.py
@@ -198,7 +198,8 @@ def generate_cpu_function_pool_pieces(functions, num_files):
                                    scheme, transpose or 'NONE',
                                    'kernel.get_kernel_config()')).inline()
         piece_contents[curr_file] += function_map.assert_insert(
-            key, var_kernel, 'def_key_pool', 'function_map', f.meta.lds_size_bytes)
+            key, var_kernel, 'def_key_pool', 'function_map',
+            f.meta.lds_size_bytes)
         curr_file = (curr_file + 1) % num_files
 
     # Assemble contents of each file to return in a list

--- a/library/src/device/kernel-generator.py
+++ b/library/src/device/kernel-generator.py
@@ -83,9 +83,9 @@ def unique(kernels):
     r, s = list(), set()
     for kernel in kernels:
         if isinstance(kernel.length, list):
-            key = tuple(kernel.length) + (kernel.scheme, )
+            key = tuple(kernel.length) + (kernel.scheme, kernel.lds_size_bytes)
         else:
-            key = (kernel.length, kernel.scheme)
+            key = (kernel.length, kernel.scheme, kernel.lds_size_bytes)
         if key not in s:
             s.add(key)
             r.append(kernel)
@@ -152,7 +152,7 @@ def generate_cpu_function_pool_main(num_files):
             type='void',
             name=f'function_pool_init_{i}',
             value=
-            'std::unordered_map<FMKey, FMKey, SimpleHash>& def_key_pool, std::unordered_map<FMKey, FFTKernel, SimpleHash>& function_map'
+            'std::unordered_multimap<FMKey, FMKey, SimpleHash>& def_key_pool, std::unordered_multimap<FMKey, FFTKernel, SimpleHash>& function_map'
         )
 
     call_list = StatementList()
@@ -198,14 +198,14 @@ def generate_cpu_function_pool_pieces(functions, num_files):
                                    scheme, transpose or 'NONE',
                                    'kernel.get_kernel_config()')).inline()
         piece_contents[curr_file] += function_map.assert_insert(
-            key, var_kernel, 'def_key_pool', 'function_map')
+            key, var_kernel, 'def_key_pool', 'function_map', f.meta.lds_size_bytes)
         curr_file = (curr_file + 1) % num_files
 
     # Assemble contents of each file to return in a list
     pieces = [None] * num_files
     piece_args = ArgumentList(
-        'std::unordered_map<FMKey, FMKey, SimpleHash>& def_key_pool',
-        'std::unordered_map<FMKey, FFTKernel, SimpleHash>& function_map')
+        'std::unordered_multimap<FMKey, FMKey, SimpleHash>& def_key_pool',
+        'std::unordered_multimap<FMKey, FFTKernel, SimpleHash>& function_map')
     for i in range(num_files):
         pieces[i] = StatementList(
             Include('"../include/function_pool.h"'),
@@ -233,6 +233,9 @@ def kernel_name(ns):
         postfix = '_sbrc'
     elif ns.scheme == 'CS_KERNEL_STOCKHAM_BLOCK_CR':
         postfix = '_sbcr'
+
+    if hasattr(ns, 'lds_size_bytes'):
+        postfix += f'_lds{ns.lds_size_bytes}'
 
     return f'rocfft_len{length}{postfix}'
 
@@ -1073,6 +1076,7 @@ def generate_kernel_functions(kernels, precisions, launchers_json):
                                  threads_per_transform=tpt_list,
                                  transpose=sbrc_transpose_type,
                                  use_3steps_large_twd=use_3steps_large_twd,
+                                 lds_size_bytes=kernel.lds_size_bytes,
                              ))
 
                 cpu_functions.append(f)
@@ -1157,7 +1161,9 @@ def generate_kernels(kernels, precisions, stockham_gen):
             proc.stdin.write(' 1' if half_lds else ' 0')
             proc.stdin.write(' 1' if direct_to_from_reg else ' 0')
             proc.stdin.write(f' {k.scheme}')
-            proc.stdin.write(f' {kernel_name(k)}\n')
+            proc.stdin.write(f' {kernel_name(k)}')
+            proc.stdin.write(f' {k.lds_size_bytes}')
+            proc.stdin.write('\n')
 
             kernel_idx += 1
             proc.stdin.flush()
@@ -1216,6 +1222,11 @@ def cli():
     all_kernels = list_small_kernels() + list_large_kernels()
 
     kernels += all_kernels + kernels_2d
+
+    # set default lds size (64k) on kernels if not specified
+    for k in kernels:
+        if not hasattr(k, 'lds_size_bytes'):
+            k.lds_size_bytes = 65536
 
     kernels = unique(kernels)
 

--- a/library/src/include/function_pool.h
+++ b/library/src/include/function_pool.h
@@ -116,8 +116,8 @@ struct function_pool_data
     // when AOT generator adds a default key-kernel,
     // we get the keys of two version: empty-config vs full-config
     // make the pair as an entry in a map so that we know they are the same things
-    std::unordered_map<FMKey, FMKey, SimpleHash>     def_key_pool;
-    std::unordered_map<FMKey, FFTKernel, SimpleHash> function_map;
+    std::unordered_multimap<FMKey, FMKey, SimpleHash>     def_key_pool;
+    std::unordered_multimap<FMKey, FFTKernel, SimpleHash> function_map;
 
     function_pool_data();
 
@@ -130,18 +130,39 @@ struct function_pool_data
 
 class function_pool
 {
-    unsigned int                                      max_lds_bytes;
-    std::unordered_map<FMKey, FMKey, SimpleHash>&     def_key_pool;
-    std::unordered_map<FMKey, FFTKernel, SimpleHash>& function_map;
+    unsigned int                                           max_lds_bytes;
+    std::unordered_multimap<FMKey, FMKey, SimpleHash>&     def_key_pool;
+    std::unordered_multimap<FMKey, FFTKernel, SimpleHash>& function_map;
 
-    const FMKey& get_actual_key(const FMKey& key) const
+    // look in the specified map for the specified key, returning an
+    // iterator to the item that fits best into the available LDS
+    template <typename Tmap>
+    typename Tmap::const_iterator find_key_in_map(const Tmap& fmap, const FMKey& key) const
+    {
+        auto   range    = fmap.equal_range(key);
+        auto   best     = fmap.end();
+        size_t best_lds = 0;
+        for(; range.first != range.second; ++range.first)
+        {
+            if(range.first->first.lds_size_bytes <= max_lds_bytes
+               && range.first->first.lds_size_bytes > best_lds)
+            {
+                best     = range.first;
+                best_lds = best->first.lds_size_bytes;
+            }
+        }
+        return best;
+    }
+
+    FMKey get_actual_key(const FMKey& key) const
     {
         // - for keys that we are querying with no/empty kernel-config, actually we are refering to
         //   the default kernel-configs in kernel-generator.py. So get the actual keys to look-up
         //   the pool.
         // - if not in the def_key_pool, then we simply use itself (for dynamically added kernel)
-        if(def_key_pool.count(key) > 0)
-            return def_key_pool.at(key);
+        auto it = find_key_in_map(def_key_pool, key);
+        if(it != def_key_pool.end())
+            return it->second;
         else
             return key;
     }
@@ -169,22 +190,25 @@ public:
 
     ~function_pool() = default;
 
-    // add a new kernel in runtime
-    bool add_new_kernel(const FMKey& new_key)
+    // Update a kernel in runtime, whose key must already exist in
+    // the function pool.  Inserting a new key would invalidate
+    // existing iterators to the pool structures.
+    void update_kernel(const FMKey& new_key)
     {
-        // already has this kernel
-        if(has_function(new_key))
-            return true;
-
-        return std::get<1>(function_map.emplace(new_key, FFTKernel(new_key.kernel_config)));
+        auto it = find_key_in_map(function_map, new_key);
+        if(it != function_map.end())
+        {
+            // so we can reuse the find_key_in_map const method, cast
+            // away const of the kernel config
+            auto& config = const_cast<FFTKernel&>(it->second);
+            config       = new_key.kernel_config;
+        }
     }
 
     bool has_function(const FMKey& key) const
     {
         auto real_key = get_actual_key(key);
-        if(!real_key.base_lds_usage_fits(max_lds_bytes))
-            return false;
-        return function_map.count(real_key) > 0;
+        return find_key_in_map(function_map, real_key) != function_map.end();
     }
 
     size_t get_largest_length(rocfft_precision precision) const
@@ -201,7 +225,7 @@ public:
         std::vector<size_t> lengths;
         for(auto const& kv : function_map)
         {
-            if(!kv.first.base_lds_usage_fits(max_lds_bytes))
+            if(kv.first.lds_size_bytes > max_lds_bytes)
                 continue;
             if(kv.first.lengths[1] == 0 && kv.first.precision == precision
                && kv.first.scheme == scheme && kv.first.sbrcTrans == NONE)
@@ -216,9 +240,10 @@ public:
     FFTKernel get_kernel(const FMKey& key) const
     {
         auto real_key = get_actual_key(key);
-        if(!real_key.base_lds_usage_fits(max_lds_bytes))
+        auto it       = find_key_in_map(function_map, real_key);
+        if(it == function_map.end())
             throw std::out_of_range("kernel not found in map");
-        return function_map.at(real_key);
+        return it->second;
     }
 
     // helper for common used
@@ -250,20 +275,25 @@ public:
 // That is, the default kernel-config we set in the kernel-generator.py we save a pair as
 // <key-empty-config, key-actual-config> that allows us to use
 // the empty-config key to get the default kernel
-static bool insert_default_entry(const FMKey&                                      def_key,
-                                 const FFTKernel&                                  kernel,
-                                 std::unordered_map<FMKey, FMKey, SimpleHash>&     def_key_pool,
-                                 std::unordered_map<FMKey, FFTKernel, SimpleHash>& function_map)
+static void
+    insert_default_entry(const FMKey&                                           def_key,
+                         const FFTKernel&                                       kernel,
+                         std::unordered_multimap<FMKey, FMKey, SimpleHash>&     def_key_pool,
+                         std::unordered_multimap<FMKey, FFTKernel, SimpleHash>& function_map,
+                         size_t                                                 lds_size_bytes)
 {
+    FMKey def_key_with_lds          = def_key;
+    def_key_with_lds.lds_size_bytes = lds_size_bytes;
+
     // simple_key means the same thing as def_key, but we just remove kernel-config
     // so we don't need to know the exact config when we're lookin' for the default kernel
-    FMKey simple_key(def_key);
+    FMKey simple_key{def_key_with_lds};
     simple_key.kernel_config = KernelConfig::EmptyConfig();
 
-    def_key_pool.emplace(simple_key, def_key);
+    def_key_pool.emplace(simple_key, def_key_with_lds);
 
     // still use the detailed key with config to maintain the function map
-    return std::get<1>(function_map.emplace(def_key, kernel));
+    function_map.emplace(def_key_with_lds, kernel);
 }
 
 #endif // FUNCTION_POOL_H

--- a/library/src/include/function_pool.h
+++ b/library/src/include/function_pool.h
@@ -154,7 +154,7 @@ class function_pool
         return best;
     }
 
-    FMKey get_actual_key(const FMKey& key) const
+    const FMKey& get_actual_key(const FMKey& key) const
     {
         // - for keys that we are querying with no/empty kernel-config, actually we are refering to
         //   the default kernel-configs in kernel-generator.py. So get the actual keys to look-up
@@ -190,19 +190,17 @@ public:
 
     ~function_pool() = default;
 
-    // Update a kernel in runtime, whose key must already exist in
-    // the function pool.  Inserting a new key would invalidate
-    // existing iterators to the pool structures.
-    void update_kernel(const FMKey& new_key)
+    // add a new kernel in runtime
+    void add_new_kernel(const FMKey& new_key)
     {
-        auto it = find_key_in_map(function_map, new_key);
-        if(it != function_map.end())
-        {
-            // so we can reuse the find_key_in_map const method, cast
-            // away const of the kernel config
-            auto& config = const_cast<FFTKernel&>(it->second);
-            config       = new_key.kernel_config;
-        }
+        // already has this kernel
+        if(has_function(new_key))
+            return;
+
+        FMKey new_key_with_lds          = new_key;
+        new_key_with_lds.lds_size_bytes = max_lds_bytes;
+
+        function_map.emplace(new_key_with_lds, FFTKernel(new_key_with_lds.kernel_config));
     }
 
     bool has_function(const FMKey& key) const

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -189,7 +189,7 @@ bool LeafNode::KernelCheck(std::vector<FMKey>& kernel_keys)
             // get sbrc_trans_type from assignedKey (for sbrc)
             sbrcTranstype = assignedKey.sbrcTrans;
 
-            pool.update_kernel(assignedKey);
+            pool.add_new_kernel(assignedKey);
             specified_key = std::make_unique<FMKey>(assignedKey);
         }
     }

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -189,7 +189,7 @@ bool LeafNode::KernelCheck(std::vector<FMKey>& kernel_keys)
             // get sbrc_trans_type from assignedKey (for sbrc)
             sbrcTranstype = assignedKey.sbrcTrans;
 
-            pool.add_new_kernel(assignedKey);
+            pool.update_kernel(assignedKey);
             specified_key = std::make_unique<FMKey>(assignedKey);
         }
     }


### PR DESCRIPTION
This makes it clearer which size a config is for, rather than trying to work that out indirectly by trying to infer how much LDS a config would use.

Originally I'd hoped that 4dc5d94daec4d4b20789eed3e101472ff8ea2e68 would be enough to handle additional LDS sizes but it's a lot more straightforward if every kernel config just explicitly knows that size it's for.