### PR TITLE
generator: add 1D configs for 160kiB LDS

### DIFF
--- a/library/src/device/kernel-generator.py
+++ b/library/src/device/kernel-generator.py
@@ -241,7 +241,8 @@ def kernel_name(ns):
     return f'rocfft_len{length}{postfix}'
 
 
-LDS_160k = 160*1024
+LDS_160k = 160 * 1024
+
 
 # yapf: disable
 def list_small_kernels():

--- a/library/src/device/kernel-generator.py
+++ b/library/src/device/kernel-generator.py
@@ -241,6 +241,8 @@ def kernel_name(ns):
     return f'rocfft_len{length}{postfix}'
 
 
+LDS_160k = 160*1024
+
 # yapf: disable
 def list_small_kernels():
     """Return list of small kernels to generate."""
@@ -709,6 +711,24 @@ def list_small_kernels():
         NS(length=6144, workgroup_size=512, threads_per_transform=512, factors=(16, 4, 8, 3, 4), double_precision=False, runtime_compile=True),
         NS(length=6561, workgroup_size=256, threads_per_transform=243, factors=(3, 3, 3, 3, 3, 3, 3, 3), double_precision=False, runtime_compile=True),
         NS(length=8192, workgroup_size=512, threads_per_transform=512, factors=(16, 4, 4, 4, 8), double_precision=False, runtime_compile=True),
+
+        # configs for 160kiB LDS
+        NS(length=4704, workgroup_size=256, threads_per_transform=224, factors=(8, 4, 7, 7, 3), lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=5488, workgroup_size=256, threads_per_transform=196, factors=(7, 4, 7, 4, 7), lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=6144, workgroup_size=384, threads_per_transform=256, factors=(4, 8, 8, 8, 3), lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=6561, workgroup_size=256, threads_per_transform=243, factors=(3, 3, 3, 3, 3, 3, 3, 3), lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=8192, workgroup_size=512, threads_per_transform=512, factors=(16, 4, 16, 8), lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=9216, workgroup_size=512, threads_per_transform=512, factors=(4, 8, 4, 4, 3, 6), lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=10000, workgroup_size=512, threads_per_transform=500, factors=(4, 5, 5, 10, 10), lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=10240, workgroup_size=512, threads_per_transform=512, factors=(8, 4, 4, 4, 5, 4), lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=10752, workgroup_size=512, threads_per_transform=512, factors=(4, 16, 8, 7, 3), double_precision=False, lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=11200, workgroup_size=512, threads_per_transform=448, factors=(4, 7, 5, 16, 5), double_precision=False, lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=12288, workgroup_size=512, threads_per_transform=512, factors=(8, 8, 4, 6, 8), double_precision=False, lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=16384, workgroup_size=512, threads_per_transform=512, factors=(8, 16, 4, 8, 4), double_precision=False, lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=16807, workgroup_size=384, threads_per_transform=343, factors=(7, 7, 7, 7, 7), double_precision=False, lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=18816, workgroup_size=512, threads_per_transform=448, factors=(8, 8, 7, 7, 6), double_precision=False, lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=19200, workgroup_size=512, threads_per_transform=480, factors=(8, 10, 8, 5, 6), double_precision=False, lds_size_bytes=LDS_160k, runtime_compile=True),
+        NS(length=20480, workgroup_size=512, threads_per_transform=512, factors=(4, 4, 16, 10, 8), double_precision=False, lds_size_bytes=LDS_160k, runtime_compile=True),
     ]
 
     kernels = [NS(**kernel.__dict__,


### PR DESCRIPTION
New lengths (single- and double- precision):
- 4704
- 5488
- 6144
- 6561
- 8192
- 9216
- 10000
- 10240

Single-precision only:
- 10752
- 11200
- 12288
- 16384
- 16807
- 18816
- 19200
- 20480

[figs-gfx950.zip](https://github.com/user-attachments/files/20065884/figs-gfx950.zip)

Attached some performance figures, looks like this is a pretty easy win.