### PR TITLE
Improve kernel io log precision

### DIFF
--- a/library/src/powX.cpp
+++ b/library/src/powX.cpp
@@ -335,19 +335,19 @@ void DebugPrintBuffer(rocfft_ostream&             stream,
         case rocfft_precision_half:
         {
             buffer_printer<rocfft_fp16> s;
-            s.print_buffer(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
+            s.print_buffer_half(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
             break;
         }
         case rocfft_precision_single:
         {
             buffer_printer<float> s;
-            s.print_buffer(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
+            s.print_buffer_single(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
             break;
         }
         case rocfft_precision_double:
         {
             buffer_printer<double> s;
-            s.print_buffer(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
+            s.print_buffer_double(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
             break;
         }
         }
@@ -364,13 +364,15 @@ void DebugPrintBuffer(rocfft_ostream&             stream,
             case rocfft_array_type_hermitian_interleaved:
             {
                 buffer_printer<rocfft_complex<rocfft_fp16>> s;
-                s.print_buffer(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
+                s.print_buffer_half(
+                    bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
                 break;
             }
             case rocfft_array_type_real:
             {
                 buffer_printer<rocfft_fp16> s;
-                s.print_buffer(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
+                s.print_buffer_half(
+                    bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
                 break;
             }
             default:
@@ -386,13 +388,15 @@ void DebugPrintBuffer(rocfft_ostream&             stream,
             case rocfft_array_type_hermitian_interleaved:
             {
                 buffer_printer<rocfft_complex<float>> s;
-                s.print_buffer(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
+                s.print_buffer_single(
+                    bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
                 break;
             }
             case rocfft_array_type_real:
             {
                 buffer_printer<float> s;
-                s.print_buffer(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
+                s.print_buffer_single(
+                    bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
                 break;
             }
             default:
@@ -408,13 +412,15 @@ void DebugPrintBuffer(rocfft_ostream&             stream,
             case rocfft_array_type_hermitian_interleaved:
             {
                 buffer_printer<rocfft_complex<double>> s;
-                s.print_buffer(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
+                s.print_buffer_double(
+                    bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
                 break;
             }
             case rocfft_array_type_real:
             {
                 buffer_printer<double> s;
-                s.print_buffer(bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
+                s.print_buffer_double(
+                    bufvec, length_rm, stride_rm, batch, dist, print_offset, stream);
                 break;
             }
             default:

--- a/shared/fft_params.h
+++ b/shared/fft_params.h
@@ -1941,19 +1941,19 @@ public:
             case fft_precision_half:
             {
                 buffer_printer<rocfft_complex<rocfft_fp16>> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_half(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             case fft_precision_single:
             {
                 buffer_printer<rocfft_complex<float>> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_single(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             case fft_precision_double:
             {
                 buffer_printer<rocfft_complex<double>> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_double(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             }
@@ -1968,19 +1968,19 @@ public:
             case fft_precision_half:
             {
                 buffer_printer<rocfft_fp16> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_half(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             case fft_precision_single:
             {
                 buffer_printer<float> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_single(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             case fft_precision_double:
             {
                 buffer_printer<double> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_double(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             }
@@ -2004,18 +2004,18 @@ public:
             case fft_precision_half:
             {
                 buffer_printer<rocfft_complex<rocfft_fp16>> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_half(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             case fft_precision_single:
             {
                 buffer_printer<rocfft_complex<float>> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_single(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             case fft_precision_double:
                 buffer_printer<rocfft_complex<double>> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_double(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             break;
@@ -2029,19 +2029,19 @@ public:
             case fft_precision_half:
             {
                 buffer_printer<rocfft_fp16> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_half(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             case fft_precision_single:
             {
                 buffer_printer<float> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_single(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             case fft_precision_double:
             {
                 buffer_printer<double> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_double(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             }

--- a/shared/printbuffer.h
+++ b/shared/printbuffer.h
@@ -24,12 +24,14 @@
 #include "hostbuf.h"
 #include "increment.h"
 #include <algorithm>
+#include <iomanip>
 #include <vector>
 
 // Output a formatted general-dimensional array with given length and stride in batches
 // separated by dist.
 template <typename Toutput, typename T1, typename T2, typename Tsize, typename Tstream>
-inline void printbuffer(const Toutput*         output,
+inline void printbuffer(const size_t&          num_decimals,
+                        const Toutput*         output,
                         const std::vector<T1>& length,
                         const std::vector<T2>& stride,
                         const Tsize            nbatch,
@@ -46,7 +48,8 @@ inline void printbuffer(const Toutput*         output,
         {
             const int i
                 = std::inner_product(index.begin(), index.end(), stride.begin(), i_base + offset);
-            stream << output[i] << " ";
+
+            stream << std::fixed << std::setprecision(num_decimals) << output[i] << " ";
             for(int li = index.size(); li-- > 0;)
             {
                 if(index[li] == (length[li] - 1))
@@ -69,24 +72,40 @@ class buffer_printer
     // The scalar versions might be part of a planar format.
 public:
     template <typename Tint1, typename Tint2, typename Tsize, typename Tstream = std::ostream>
-    static void print_buffer(const std::vector<hostbuf>& buf,
-                             const std::vector<Tint1>&   length,
-                             const std::vector<Tint2>&   stride,
-                             const Tsize                 nbatch,
-                             const Tsize                 dist,
-                             const std::vector<size_t>&  offset,
-                             Tstream&                    stream = std::cout)
+    static void print_buffer_half(const std::vector<hostbuf>& buf,
+                                  const std::vector<Tint1>&   length,
+                                  const std::vector<Tint2>&   stride,
+                                  const Tsize                 nbatch,
+                                  const Tsize                 dist,
+                                  const std::vector<size_t>&  offset,
+                                  Tstream&                    stream = std::cout)
     {
-        for(const auto& vec : buf)
-        {
-            printbuffer(reinterpret_cast<const Telem*>(vec.data()),
-                        length,
-                        stride,
-                        nbatch,
-                        dist,
-                        offset[0],
-                        stream);
-        }
+        auto num_decimals = 3;
+        print_buffer(num_decimals, buf, length, stride, nbatch, dist, offset, stream);
+    };
+    template <typename Tint1, typename Tint2, typename Tsize, typename Tstream = std::ostream>
+    static void print_buffer_single(const std::vector<hostbuf>& buf,
+                                    const std::vector<Tint1>&   length,
+                                    const std::vector<Tint2>&   stride,
+                                    const Tsize                 nbatch,
+                                    const Tsize                 dist,
+                                    const std::vector<size_t>&  offset,
+                                    Tstream&                    stream = std::cout)
+    {
+        auto num_decimals = 6;
+        print_buffer(num_decimals, buf, length, stride, nbatch, dist, offset, stream);
+    };
+    template <typename Tint1, typename Tint2, typename Tsize, typename Tstream = std::ostream>
+    static void print_buffer_double(const std::vector<hostbuf>& buf,
+                                    const std::vector<Tint1>&   length,
+                                    const std::vector<Tint2>&   stride,
+                                    const Tsize                 nbatch,
+                                    const Tsize                 dist,
+                                    const std::vector<size_t>&  offset,
+                                    Tstream&                    stream = std::cout)
+    {
+        auto num_decimals = 15;
+        print_buffer(num_decimals, buf, length, stride, nbatch, dist, offset, stream);
     };
     template <typename Tstream = std::ostream>
     static void print_buffer_flat(const std::vector<hostbuf>& buf,
@@ -101,6 +120,30 @@ public:
             for(size_t i = 0; i < size[0]; ++i)
                 stream << " " << data[i];
             stream << std::endl;
+        }
+    };
+
+private:
+    template <typename Tint1, typename Tint2, typename Tsize, typename Tstream = std::ostream>
+    static void print_buffer(const size_t&               num_decimals,
+                             const std::vector<hostbuf>& buf,
+                             const std::vector<Tint1>&   length,
+                             const std::vector<Tint2>&   stride,
+                             const Tsize                 nbatch,
+                             const Tsize                 dist,
+                             const std::vector<size_t>&  offset,
+                             Tstream&                    stream)
+    {
+        for(const auto& vec : buf)
+        {
+            printbuffer(num_decimals,
+                        reinterpret_cast<const Telem*>(vec.data()),
+                        length,
+                        stride,
+                        nbatch,
+                        dist,
+                        offset[0],
+                        stream);
         }
     };
 };


### PR DESCRIPTION
External user scripts that rely on kernel io logs with ROCFFT_LAYER=16 can have trouble with the precision of the logged data. 

For example, if an external script tries to compare the kernel ouput data in double-precision with another FFT implementation, accuracy comparisons may fail because the log is not being printed out with the required precision.

This PR changes printbuffer to use the actual precision that the input/output data was generated/computed, and change the data stream to print with a predefined number of decimals.