### PR TITLE
node_factory: only use pow2 kernels to decompose pow2 lengths

### DIFF
--- a/library/src/include/function_pool.h
+++ b/library/src/include/function_pool.h
@@ -26,6 +26,7 @@
 #include "../../../shared/rocfft_complex.h"
 #include "../device/kernels/common.h"
 #include "function_map_key.h"
+#include <functional>
 #include <sstream>
 #include <unordered_map>
 
@@ -196,7 +197,10 @@ public:
         return 0;
     }
 
-    std::vector<size_t> get_lengths(rocfft_precision precision, ComputeScheme scheme) const
+    // Optional filter can be specified to only get lengths where the filter returns true
+    std::vector<size_t> get_lengths(rocfft_precision            precision,
+                                    ComputeScheme               scheme,
+                                    std::function<bool(size_t)> filter = {}) const
     {
         std::vector<size_t> lengths;
         for(auto const& kv : function_map)
@@ -206,7 +210,10 @@ public:
             if(kv.first.lengths[1] == 0 && kv.first.precision == precision
                && kv.first.scheme == scheme && kv.first.sbrcTrans == NONE)
             {
-                lengths.push_back(kv.first.lengths[0]);
+                if(!filter || filter(kv.first.lengths[0]))
+                {
+                    lengths.push_back(kv.first.lengths[0]);
+                }
             }
         }
 

--- a/library/src/node_factory.cpp
+++ b/library/src/node_factory.cpp
@@ -658,7 +658,11 @@ ComputeScheme NodeFactory::Decide1DScheme(const function_pool& pool, NodeMetaDat
         }
         else
         {
-            auto largest = pool.get_largest_length(nodeData.precision);
+            // get largest pow2 1D length
+            auto pow2_lengths = pool.get_lengths(
+                nodeData.precision, CS_KERNEL_STOCKHAM, [](size_t len) { return IsPo2(len); });
+            auto largest = *std::max_element(pow2_lengths.cbegin(), pow2_lengths.cend());
+
             // need to ignore len 1, or we're going into a infinity decompostion loop
             // basically not gonna happen unless someone builds only a len1 kernel...
             if(largest <= 1)

--- a/library/src/node_factory.cpp
+++ b/library/src/node_factory.cpp
@@ -693,17 +693,18 @@ ComputeScheme
             // get largest pow2 1D length
             auto pow2_lengths = pool.get_lengths(
                 nodeData.precision, CS_KERNEL_STOCKHAM, [](size_t len) { return IsPo2(len); });
-            auto largest = *std::max_element(pow2_lengths.cbegin(), pow2_lengths.cend());
+
+            auto largest = std::max_element(pow2_lengths.cbegin(), pow2_lengths.cend());
 
             // need to ignore len 1, or we're going into a infinity decompostion loop
             // basically not gonna happen unless someone builds only a len1 kernel...
-            if(largest <= 1)
+            if(largest == pow2_lengths.cend() || *largest <= 1)
             {
                 failed = true;
             }
-            else if(nodeData.length[0] > largest * largest)
+            else if(nodeData.length[0] > *largest * *largest)
             {
-                divLength1 = nodeData.length[0] / largest;
+                divLength1 = nodeData.length[0] / *largest;
             }
             else
             {


### PR DESCRIPTION
Fixes a problem where pow2 decomposition code was incorrectly assuming the largest 1D length in the pool is also pow2.