### PR TITLE
bluestein: only look for pow2 lengths for single-kernel

### DIFF
--- a/library/src/include/function_pool.h
+++ b/library/src/include/function_pool.h
@@ -23,6 +23,7 @@
 #ifndef FUNCTION_POOL_H
 #define FUNCTION_POOL_H
 
+#include "../../../shared/arithmetic.h"
 #include "../../../shared/rocfft_complex.h"
 #include "../device/kernels/common.h"
 #include "function_map_key.h"
@@ -219,10 +220,11 @@ public:
         return find_key_in_map(function_map, real_key) != function_map.end();
     }
 
-    size_t get_largest_length(rocfft_precision precision) const
+    size_t get_largest_pow2_length(rocfft_precision precision) const
     {
-        auto supported = get_lengths(precision, CS_KERNEL_STOCKHAM);
-        auto itr       = std::max_element(supported.cbegin(), supported.cend());
+        auto supported
+            = get_lengths(precision, CS_KERNEL_STOCKHAM, [](size_t len) { return IsPo2(len); });
+        auto itr = std::max_element(supported.cbegin(), supported.cend());
         if(itr != supported.cend())
             return *itr;
         return 0;

--- a/library/src/node_factory.cpp
+++ b/library/src/node_factory.cpp
@@ -691,20 +691,17 @@ ComputeScheme
         else
         {
             // get largest pow2 1D length
-            auto pow2_lengths = pool.get_lengths(
-                nodeData.precision, CS_KERNEL_STOCKHAM, [](size_t len) { return IsPo2(len); });
-
-            auto largest = std::max_element(pow2_lengths.cbegin(), pow2_lengths.cend());
+            auto largest = pool.get_largest_pow2_length(nodeData.precision);
 
             // need to ignore len 1, or we're going into a infinity decompostion loop
             // basically not gonna happen unless someone builds only a len1 kernel...
-            if(largest == pow2_lengths.cend() || *largest <= 1)
+            if(largest <= 1)
             {
                 failed = true;
             }
-            else if(nodeData.length[0] > *largest * *largest)
+            else if(nodeData.length[0] > largest * largest)
             {
-                divLength1 = nodeData.length[0] / *largest;
+                divLength1 = nodeData.length[0] / largest;
             }
             else
             {

--- a/library/src/tree_node_bluestein.cpp
+++ b/library/src/tree_node_bluestein.cpp
@@ -95,6 +95,9 @@ BluesteinType BluesteinNode::DecideBlueType()
         return type;
     }
 
+    // Handle lengthBlue with its own non-fused FFT sub-plan.  This
+    // can be a multi-kernel L1D plan, or a 1-kernel Stockham plan if
+    // lengthBlue can be done with a single non-pow2 kernel.
     if(scheme == CS_L1D_CRT || scheme == CS_L1D_TRTRT || scheme == CS_KERNEL_STOCKHAM)
         return BluesteinType::BT_MULTI_KERNEL;
 

--- a/library/src/tree_node_bluestein.cpp
+++ b/library/src/tree_node_bluestein.cpp
@@ -95,7 +95,7 @@ BluesteinType BluesteinNode::DecideBlueType()
         return type;
     }
 
-    if(scheme == CS_L1D_CRT || scheme == CS_L1D_TRTRT)
+    if(scheme == CS_L1D_CRT || scheme == CS_L1D_TRTRT || scheme == CS_KERNEL_STOCKHAM)
         return BluesteinType::BT_MULTI_KERNEL;
 
     return BluesteinType::BT_NONE;
@@ -420,8 +420,9 @@ bool BluesteinSingleNode::SizeFits(const function_pool& pool,
                                    size_t               length,
                                    rocfft_precision     precision)
 {
-    // 2N - 1 must fit into a single kernel
-    return 2 * length - 1 < pool.get_largest_length(precision);
+    // 2N - 1 must fit into a single kernel, and single-kernel
+    // Bluestein only uses pow2 FFT
+    return 2 * length - 1 < pool.get_largest_pow2_length(precision);
 }
 
 size_t BluesteinSingleNode::GetTwiddleTableLength()


### PR DESCRIPTION
Randomized tests noticed that real_forward_len_9409_single_ip_batch_1_istride_1_R_ostride_1_HI_idist_9410_odist_4705_ioffset_0_0_ooffset_0_0 broke, because single-kernel Bluestein was also trying to use `function_pool::get_largest_length` and assuming the largest length was pow2.  But since 9e97f280762b12c6e7085f614ccf19a05aee9df3 and this are the only things that need `function_pool::get_largest_length`, I've instead renamed that to `get_largest_pow2_length` and used it in both places.