### PR TITLE
cmake: use FetchContent to get rocm-cmake-build-tools if necessary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,30 +54,20 @@ project( rocfft LANGUAGES CXX C )
 set( PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern )
 find_package( ROCmCMakeBuildTools PATHS ${ROCM_PATH} /opt/rocm )
 if( NOT ROCmCMakeBuildTools_FOUND )
-  set( rocm_cmake_tag "develop" CACHE STRING "rocm-cmake tag to download" )
-  file( DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
-      ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip STATUS status LOG log)
+  include( FetchContent )
 
-  list(GET status 0 status_code)
-  list(GET status 1 status_string)
+  FetchContent_Declare( rocm_cmake_local
+    GIT_REPOSITORY https://github.com/ROCm/rocm-cmake-build-tools
+    GIT_TAG rocm-6.4.1
+    GIT_SHALLOW ON
+  )
 
-  if(NOT status_code EQUAL 0)
-    message(FATAL_ERROR "error: downloading
-    'https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip' failed
-    status_code: ${status_code}
-    status_string: ${status_string}
-    log: ${log}
-    ")
-  endif()
+  FetchContent_MakeAvailable( rocm_cmake_local )
 
-  message(STATUS "downloading... done")
-
-  execute_process( COMMAND ${CMAKE_COMMAND} -E tar xzvf ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
-    WORKING_DIRECTORY ${PROJECT_EXTERN_DIR} )
   execute_process( COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${PROJECT_EXTERN_DIR}/rocm-cmake .
-    WORKING_DIRECTORY ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag} )
-  execute_process( COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
-    WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
+    WORKING_DIRECTORY ${rocm_cmake_local_SOURCE_DIR} )
+  execute_process( COMMAND ${CMAKE_COMMAND} --build ${rocm_cmake_local_SOURCE_DIR} --target install
+    WORKING_DIRECTORY ${rocm_cmake_local_SOURCE_DIR} )
 
   find_package( ROCmCMakeBuildTools REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake )
 endif( )


### PR DESCRIPTION
rocm-cmake has been renamed to rocm-cmake-build-tools, so update the
repository URL.  While we're at it, use FetchContent to download as
it's less sensitive to changes on the rocm-cmake-build-tools side, and
we can ask for a specific tag instead of the tip of develop.