### PR TITLE
sys_mem: check /proc/meminfo to get available memory

### DIFF
--- a/shared/sys_mem.h
+++ b/shared/sys_mem.h
@@ -122,7 +122,7 @@ private:
             std::string   proc_line;
             while(std::getline(proc_meminfo, proc_line))
             {
-                // meminfo counts in kiB
+                // meminfo counts in KiB
                 if(proc_line.compare(0, 9, "MemTotal:") == 0)
                     total_bytes = std::stoull(proc_line.substr(9)) * 1024;
                 else if(proc_line.compare(0, 13, "MemAvailable:") == 0)

--- a/shared/sys_mem.h
+++ b/shared/sys_mem.h
@@ -111,11 +111,42 @@ private:
         total_bytes = info.ullTotalPhys;
         free_bytes  = info.ullAvailPhys;
 #else
-        struct sysinfo info;
-        if(sysinfo(&info) != 0)
-            return;
-        total_bytes = info.totalram * info.mem_unit;
-        free_bytes  = (info.freeram + info.bufferram) * info.mem_unit;
+
+        // /proc/meminfo can tell us "available" memory (i.e. free +
+        // buffers + cache)
+        total_bytes = 0;
+        free_bytes  = 0;
+        try
+        {
+            std::ifstream proc_meminfo("/proc/meminfo");
+            std::string   proc_line;
+            while(std::getline(proc_meminfo, proc_line))
+            {
+                // meminfo counts in kiB
+                if(proc_line.compare(0, 9, "MemTotal:") == 0)
+                    total_bytes = std::stoull(proc_line.substr(9)) * 1024;
+                else if(proc_line.compare(0, 13, "MemAvailable:") == 0)
+                    free_bytes = std::stoull(proc_line.substr(13)) * 1024;
+                if(total_bytes && free_bytes)
+                    break;
+            }
+        }
+        catch(std::exception&)
+        {
+            // If there was a problem, we'll fall back to sysinfo
+        }
+
+        if(total_bytes == 0)
+        {
+            // Either something couldn't be parsed or proc is not
+            // mounted.  Fall back to sysinfo which can tell total +
+            // free, but not "available".
+            struct sysinfo info;
+            if(sysinfo(&info) != 0)
+                return;
+            total_bytes = info.totalram * info.mem_unit;
+            free_bytes  = (info.freeram + info.bufferram) * info.mem_unit;
+        }
 
         // Adjust memory numbers for APU
         try


### PR DESCRIPTION
sysinfo(2) is unaware of cache, but we can still fall back to it in case /proc/meminfo isn't available.

After testing some more on my integrated gfx1035 I realized #595 is too pessimistic.  [sysinfo(2)](https://linux.die.net/man/2/sysinfo) is unable to get the same information that [free(1)](https://linux.die.net/man/1/free) gets, and we're really interested in the "available" number.

So for example, with 32 GiB system memory (16 GiB allocated to GPU) `free` says I have 12 GiB free and 11 GiB cached (23 GiB available).  With the code that only looks at `sysinfo` none of the test cases will run - when we take away the 16 GiB for the GPU from 12 GIB free, there's nothing left.

free(1) ultimately looks at /proc/meminfo to know its numbers so just look there first.
