### PR TITLE
Fix for possible false positives in testing when using cached results and non-unit scale factor

### DIFF
--- a/shared/accuracy_test.h
+++ b/shared/accuracy_test.h
@@ -53,6 +53,7 @@ struct last_cpu_fft_cache
     fft_transform_type  transform_type = fft_transform_type_complex_forward;
     bool                run_callbacks  = false;
     fft_precision       precision      = fft_precision_single;
+    double              scale_factor   = 1.0;
 
     // FFTW input/output
     std::vector<hostbuf> cpu_input;
@@ -851,7 +852,8 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
     std::unique_ptr<StoreCPUDataToCache> store_to_cache;
     if(fftw_compare && last_cpu_fft_data.length == params.length
        && last_cpu_fft_data.transform_type == params.transform_type
-       && last_cpu_fft_data.run_callbacks == params.run_callbacks)
+       && last_cpu_fft_data.run_callbacks == params.run_callbacks
+       && last_cpu_fft_data.scale_factor == params.scale_factor)
     {
         if(last_cpu_fft_data.nbatch >= params.nbatch)
         {
@@ -859,20 +861,6 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
             cpu_input.swap(last_cpu_fft_data.cpu_input);
             cpu_output.swap(last_cpu_fft_data.cpu_output);
             run_fftw = false;
-            if(params.scale_factor != 1.0)
-            {
-                // cpu_output was stored *unscaled* in cache; scale it as
-                // required before using it for comparison purposes
-                bool tmp_run_callbacks = false;
-                auto tmp_precision     = last_cpu_fft_data.precision;
-                // scale the (cached) results as required
-                std::swap(params.run_callbacks, tmp_run_callbacks);
-                std::swap(params.precision, tmp_precision);
-                apply_store_callback(params, cpu_output);
-                // restore params to what it was
-                std::swap(params.run_callbacks, tmp_run_callbacks);
-                std::swap(params.precision, tmp_precision);
-            }
 
             store_to_cache = std::make_unique<StoreCPUDataToCache>(cpu_input, cpu_output);
 
@@ -1392,6 +1380,7 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
           || last_cpu_fft_data.transform_type != params.transform_type
           || last_cpu_fft_data.run_callbacks != params.run_callbacks
           || last_cpu_fft_data.precision != params.precision
+          || last_cpu_fft_data.scale_factor != params.scale_factor
           || params.nbatch > last_cpu_fft_data.nbatch;
 
     // store cpu output in cache
@@ -1402,24 +1391,11 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
         last_cpu_fft_data.transform_type = params.transform_type;
         last_cpu_fft_data.run_callbacks  = params.run_callbacks;
         last_cpu_fft_data.precision      = params.precision;
+        last_cpu_fft_data.scale_factor   = params.scale_factor;
     }
 
     if(compare_output.valid())
         compare_output.get();
-
-    if(params.scale_factor != 1.0)
-    {
-        // keep cpu_output *unscaled* in cache to make it reusable thereafter.
-        // Revert scaling factor:
-        auto tmp_scale_factor  = 1.0 / params.scale_factor;
-        bool tmp_run_callbacks = false;
-        std::swap(params.scale_factor, tmp_scale_factor);
-        std::swap(params.run_callbacks, tmp_run_callbacks);
-        apply_store_callback(params, cpu_output);
-        // restore params to what it was
-        std::swap(params.scale_factor, tmp_scale_factor);
-        std::swap(params.run_callbacks, tmp_run_callbacks);
-    }
 
     if(!store_to_cache)
         store_to_cache = std::make_unique<StoreCPUDataToCache>(cpu_input, cpu_output);

--- a/shared/accuracy_test.h
+++ b/shared/accuracy_test.h
@@ -863,12 +863,15 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
             {
                 // cpu_output was stored *unscaled* in cache; scale it as
                 // required before using it for comparison purposes
-                // temporary lower run_callbacks flag
-                bool no_run_callbacks = false;
-                std::swap(params.run_callbacks, no_run_callbacks);
+                bool tmp_run_callbacks = false;
+                auto tmp_precision     = last_cpu_fft_data.precision;
+                // scale the (cached) results as required
+                std::swap(params.run_callbacks, tmp_run_callbacks);
+                std::swap(params.precision, tmp_precision);
                 apply_store_callback(params, cpu_output);
                 // restore params to what it was
-                std::swap(params.run_callbacks, no_run_callbacks);
+                std::swap(params.run_callbacks, tmp_run_callbacks);
+                std::swap(params.precision, tmp_precision);
             }
 
             store_to_cache = std::make_unique<StoreCPUDataToCache>(cpu_input, cpu_output);
@@ -1404,23 +1407,22 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
     if(compare_output.valid())
         compare_output.get();
 
-    if(!store_to_cache)
+    if(params.scale_factor != 1.0)
     {
-        if(params.scale_factor != 1.0)
-        {
-            // keep cpu_output *unscaled* in cache to make it reusable thereafter.
-            // temporarily modify params to revert the effects of scale_factor
-            double reciprocal_scale_factor = 1.0 / params.scale_factor;
-            bool   no_run_callbacks        = false;
-            std::swap(params.scale_factor, reciprocal_scale_factor);
-            std::swap(params.run_callbacks, no_run_callbacks);
-            apply_store_callback(params, cpu_output);
-            // restore params to what it was
-            std::swap(params.scale_factor, reciprocal_scale_factor);
-            std::swap(params.run_callbacks, no_run_callbacks);
-        }
-        store_to_cache = std::make_unique<StoreCPUDataToCache>(cpu_input, cpu_output);
+        // keep cpu_output *unscaled* in cache to make it reusable thereafter.
+        // Revert scaling factor:
+        auto tmp_scale_factor  = 1.0 / params.scale_factor;
+        bool tmp_run_callbacks = false;
+        std::swap(params.scale_factor, tmp_scale_factor);
+        std::swap(params.run_callbacks, tmp_run_callbacks);
+        apply_store_callback(params, cpu_output);
+        // restore params to what it was
+        std::swap(params.scale_factor, tmp_scale_factor);
+        std::swap(params.run_callbacks, tmp_run_callbacks);
     }
+
+    if(!store_to_cache)
+        store_to_cache = std::make_unique<StoreCPUDataToCache>(cpu_input, cpu_output);
 
     Tparams params_inverse;
 

--- a/shared/accuracy_test.h
+++ b/shared/accuracy_test.h
@@ -859,6 +859,17 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
             cpu_input.swap(last_cpu_fft_data.cpu_input);
             cpu_output.swap(last_cpu_fft_data.cpu_output);
             run_fftw = false;
+            if(params.scale_factor != 1.0)
+            {
+                // cpu_output was stored *unscaled* in cache; scale it as
+                // required before using it for comparison purposes
+                // temporary lower run_callbacks flag
+                bool no_run_callbacks = false;
+                std::swap(params.run_callbacks, no_run_callbacks);
+                apply_store_callback(params, cpu_output);
+                // restore params to what it was
+                std::swap(params.run_callbacks, no_run_callbacks);
+            }
 
             store_to_cache = std::make_unique<StoreCPUDataToCache>(cpu_input, cpu_output);
 
@@ -1394,7 +1405,22 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
         compare_output.get();
 
     if(!store_to_cache)
+    {
+        if(params.scale_factor != 1.0)
+        {
+            // keep cpu_output *unscaled* in cache to make it reusable thereafter.
+            // temporarily modify params to revert the effects of scale_factor
+            double reciprocal_scale_factor = 1.0 / params.scale_factor;
+            bool   no_run_callbacks        = false;
+            std::swap(params.scale_factor, reciprocal_scale_factor);
+            std::swap(params.run_callbacks, no_run_callbacks);
+            apply_store_callback(params, cpu_output);
+            // restore params to what it was
+            std::swap(params.scale_factor, reciprocal_scale_factor);
+            std::swap(params.run_callbacks, no_run_callbacks);
+        }
         store_to_cache = std::make_unique<StoreCPUDataToCache>(cpu_input, cpu_output);
+    }
 
     Tparams params_inverse;
 
@@ -1464,13 +1490,14 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
         EXPECT_TRUE(diff.l_inf <= linf_cutoff)
             << "Linf test failed.  Linf:" << diff.l_inf
             << "\tnormalized Linf: " << diff.l_inf / cpu_output_norm.l_inf
-            << "\tcutoff: " << linf_cutoff << params.str();
+            << "\tcutoff: " << linf_cutoff << "\n"
+            << params.str();
 
         EXPECT_TRUE(diff.l_2 / cpu_output_norm.l_2
                     <= sqrt(log2(total_length)) * type_epsilon(params.precision))
             << "L2 test failed. L2: " << diff.l_2
             << "\tnormalized L2: " << diff.l_2 / cpu_output_norm.l_2
-            << "\tepsilon: " << sqrt(log2(total_length)) * type_epsilon(params.precision)
+            << "\tepsilon: " << sqrt(log2(total_length)) * type_epsilon(params.precision) << "\n"
             << params.str();
     }
 


### PR DESCRIPTION
Self-explanatory title

Example of current false-positive failure addressed with the suggestion (on gfx1201):
`./rocfft-test --smoketest --seed 4697 --gtest_filter=*4_4_8192*`

Will need to be cherry-picked in hipFFT if/once merged.