### PR TITLE
Use same multi-gpu identifier when reading and writing test tokens

### DIFF
--- a/shared/fft_params.h
+++ b/shared/fft_params.h
@@ -1206,7 +1206,7 @@ public:
             ++pos;
         }
 
-        if(pos < vals.size() && vals[pos] == "multiGPU")
+        if(pos < vals.size() && vals[pos] == "multigpu")
         {
             ++pos;
             multiGPU = std::stoull(vals[pos++]);


### PR DESCRIPTION
Copy-pasting a previously-generated multi-gpu test token fails to set up a multi-gpu test because the identifier used in reading differs from what was used in writing (line 1051 in the same file).