### PR TITLE
Remove File reorganization backward computability (rocFFT)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,17 +120,6 @@ endif( )
 # Split up function pool compilation across N files to parallelize its build
 set(ROCFFT_FUNCTION_POOL_N 8 CACHE STRING "Number of files to split function_pool into for compilation")
 
-# FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
-option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" OFF)
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
-  rocm_wrap_header_dir(
-    ${CMAKE_SOURCE_DIR}/library/include
-    PATTERNS "*.h"
-    GUARDS SYMLINK WRAPPER
-    WRAPPER_LOCATIONS ${CMAKE_INSTALL_INCLUDEDIR}
-  )
-endif()
-
 set( WARNING_FLAGS -Wall -Wno-unused-function -Wimplicit-fallthrough -Wunreachable-code -Wsign-compare -Wno-deprecated-declarations )
 if( WERROR )
   set( WARNING_FLAGS ${WARNING_FLAGS} -Werror )

--- a/install.sh
+++ b/install.sh
@@ -279,7 +279,6 @@ group_num=false
 manual_small_arg=false
 manual_large_arg=false
 build_address_sanitizer=false
-build_freorg_bkwdcomp=false
 solmap_data_folder=false
 
 # #################################################
@@ -328,9 +327,6 @@ while true; do
             shift ;;
         --address-sanitizer)
             build_address_sanitizer=true
-            shift ;;
-        --rm-legacy-include-dir)
-            build_freorg_bkwdcomp=false
             shift ;;
         --prefix)
             echo $2
@@ -439,11 +435,6 @@ if [[ "${build_address_sanitizer}" == true ]]; then
     cmake_common_options="$cmake_common_options -DBUILD_ADDRESS_SANITIZER=ON"
 fi
 
-if [[ "${build_freorg_bkwdcomp}" == true ]]; then
-  cmake_common_options="${cmake_common_options} -DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=ON"
-else
-  cmake_common_options="${cmake_common_options} -DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF"
-fi
 # generator
 if [[ "${pattern_arg}" != false ]]; then
     cmake_common_options="${cmake_common_options} -DGENERATOR_PATTERN=${pattern_arg}"

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -559,15 +559,6 @@ set_target_properties( rocfft PROPERTIES CXX_VISIBILITY_PRESET "hidden" VISIBILI
 
 generate_export_header( rocfft EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/rocfft/rocfft-export.h )
 
-if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
-  rocm_wrap_header_file(
-    rocfft-version.h rocfft-export.h
-    GUARDS SYMLINK WRAPPER
-    WRAPPER_LOCATIONS ${CMAKE_INSTALL_INCLUDEDIR} rocfft/${CMAKE_INSTALL_INCLUDEDIR}
-    ORIGINAL_FILES ${PROJECT_BINARY_DIR}/include/rocfft/rocfft-version.h
-  )
-endif( )
-
 # Following Boost conventions of prefixing 'lib' on static built libraries, across all platforms
 if( NOT BUILD_SHARED_LIBS )
   set_target_properties( rocfft PROPERTIES PREFIX "lib" )
@@ -622,11 +613,3 @@ rocm_export_targets(
     ${static_depends}
   NAMESPACE roc::
   )
-
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
-  rocm_install(
-    DIRECTORY
-       "${PROJECT_BINARY_DIR}/rocfft"
-        DESTINATION "." )
-  message( STATUS "Backward Compatible Sym Link Created for include directories" )
-endif()


### PR DESCRIPTION
Summary of proposed changes:
remove backwards compatibility code in hipFFT. Feature has been disabled related code is not needed.