### PR TITLE
Enable CommAllToAll for Pencil Decompositions using MPI Sub-Communicators

### DIFF
--- a/library/src/include/plan.h
+++ b/library/src/include/plan.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2016 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -134,6 +134,12 @@ struct rocfft_plan_description_t
     rocfft_comm_type comm_type = rocfft_comm_none;
 #ifdef ROCFFT_MPI_ENABLE
     MPI_Comm_wrapper_t mpi_comm;
+    bool               use_subcomm = false;
+    MPI_Comm_wrapper_t subcomm;
+
+    // hard-coded test
+    std::vector<int> imgrid = {16, 8, 1};
+    std::vector<int> omgrid = {16, 8, 1};
 #endif
 
     LoadOps  loadOps;

--- a/library/src/include/rocfft_mpi.h
+++ b/library/src/include/rocfft_mpi.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -92,6 +92,16 @@ public:
     bool operator!() const
     {
         return mpi_comm == MPI_COMM_NULL;
+    }
+
+    // split communicator
+    void split(MPI_Comm parent, int group, int key)
+    {
+        free(); // release any old communicator
+        if(parent != MPI_COMM_NULL && MPI_Comm_split(parent, group, key, &mpi_comm) != MPI_SUCCESS)
+        {
+            throw std::runtime_error("MPI_Comm_split failed");
+        }
     }
 
 private:

--- a/library/src/include/tree_node.h
+++ b/library/src/include/tree_node.h
@@ -45,6 +45,10 @@
 #include "rtc_kernel.h"
 #include <hip/hip_runtime_api.h>
 
+#ifdef ROCFFT_MPI_ENABLE
+#include <mpi.h>
+#endif
+
 enum NodeType
 {
     NT_UNDEFINED, // un init
@@ -840,7 +844,7 @@ public:
         : comm_rank(comm_rank)
     {
     }
-    InternalTempBuffer(const InternalTempBuffer&) = delete;
+    InternalTempBuffer(const InternalTempBuffer&)            = delete;
     InternalTempBuffer& operator=(const InternalTempBuffer&) = delete;
     ~InternalTempBuffer()                                    = default;
 
@@ -896,8 +900,8 @@ private:
 class BufferPtr
 {
 public:
-    BufferPtr()                 = default;
-    BufferPtr(const BufferPtr&) = default;
+    BufferPtr()                            = default;
+    BufferPtr(const BufferPtr&)            = default;
     BufferPtr& operator=(const BufferPtr&) = default;
     ~BufferPtr()                           = default;
 
@@ -1024,7 +1028,7 @@ struct MultiPlanItem
 {
     MultiPlanItem();
     virtual ~MultiPlanItem();
-    MultiPlanItem(const MultiPlanItem&) = delete;
+    MultiPlanItem(const MultiPlanItem&)            = delete;
     MultiPlanItem& operator=(const MultiPlanItem&) = delete;
 
     // multi-process requests
@@ -1447,6 +1451,9 @@ private:
     // send/receive buffers
     const BufferPtr sendBuf;
     const BufferPtr recvBuf;
+
+    // set during ExecuteAsync, used in Print
+    mutable MPI_Comm comm = MPI_COMM_NULL;
 };
 
 // Tree-structured FFT plan.  This is specific to a single device on

--- a/library/src/plan.cpp
+++ b/library/src/plan.cpp
@@ -1199,7 +1199,7 @@ struct TempBufferLease
         buf         = std::move(other.buf);
         return *this;
     }
-    TempBufferLease(const TempBufferLease& other) = delete;
+    TempBufferLease(const TempBufferLease& other)            = delete;
     TempBufferLease& operator=(const TempBufferLease& other) = delete;
 
     std::shared_ptr<InternalTempBuffer> data()
@@ -1386,6 +1386,7 @@ std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t current
                                                    brick.contiguous_strides(),
                                                    std::move(description)),
                                    antecedents);
+
             AddAntecedent(gatherIdx, packIdx);
 
             gather->AddOperation(local_comm_rank,
@@ -1979,6 +1980,7 @@ void rocfft_plan_t::GlobalTranspose(size_t                     elem_size,
                                     std::vector<size_t>&       outputItems,
                                     size_t                     transposeNumber)
 {
+
     // All-to-all transpose is preferred as it's faster. This requires
     // that each rank have a single base pointer to send/receive with
     // offsets for every other rank.
@@ -2014,8 +2016,7 @@ void rocfft_plan_t::GlobalTransposeP2P(size_t                     elem_size,
                                        const std::string&         itemGroup)
 {
     std::vector<TempBufferLease> packBufs;
-
-    const auto local_comm_rank = get_local_comm_rank();
+    const auto                   local_comm_rank = get_local_comm_rank();
 
     // loop over each input brick, finding the intersection of it with
     // every output brick
@@ -2291,6 +2292,64 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
     outputItems = unpack_ops;
 }
 
+// check whether the input and output fields can be used for pencil decomposition
+static bool is_uniform_pencil(const rocfft_field_t& inField, const rocfft_field_t& outField)
+{
+    if(inField.bricks.size() != outField.bricks.size() || inField.bricks.empty())
+        return false;
+
+    size_t count = inField.bricks[0].count_elems();
+    for(size_t i = 0; i < inField.bricks.size(); ++i)
+    {
+        if(inField.bricks[i].count_elems() != count || outField.bricks[i].count_elems() != count)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+// create an intermediate field aligned along a given dimension
+rocfft_field_t create_intermediate_field(const rocfft_plan_description_t& desc, int alignedDim)
+{
+    rocfft_field_t newField;
+    const auto&    srcField = desc.inFields.front();
+
+    newField.bricks.resize(srcField.bricks.size());
+
+    for(size_t i = 0; i < srcField.bricks.size(); ++i)
+    {
+        const auto&    brick = srcField.bricks[i];
+        rocfft_brick_t newBrick;
+
+        newBrick.lower    = brick.lower;
+        newBrick.upper    = brick.upper;
+        newBrick.location = brick.location;
+
+        auto                len = brick.length();
+        std::vector<size_t> perm(len.size());
+        std::iota(perm.begin(), perm.end(), 0);
+
+        // move alignedDim to the front
+        std::rotate(perm.begin(), perm.begin() + alignedDim, perm.begin() + alignedDim + 1);
+
+        // compute strides so that alignedDim is the fastest
+        std::vector<size_t> strides(len.size());
+        size_t              s = 1;
+        for(size_t j = 0; j < perm.size(); ++j)
+        {
+            strides[perm[j]] = s;
+            s *= len[perm[j]];
+        }
+
+        newBrick.stride = strides;
+
+        newField.bricks[i] = newBrick;
+    }
+
+    return newField;
+}
+
 bool rocfft_plan_t::BuildOptMultiDevicePlan()
 {
     const auto local_comm_rank = get_local_comm_rank();
@@ -2330,9 +2389,89 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
     if(contiguousInputDims.empty() || contiguousOutputDims.empty())
         return false;
 
-    const auto elem_size = element_size(precision, desc.inArrayType);
+    // enable pencil decomposition:
+    // create OptMultiDevicePlan using CommAllToAll with subcommunicators
+    if(is_uniform_pencil(desc.inFields.front(), desc.outFields.front()))
+    {
 
+        int Px = desc.imgrid[0];
+        int Py = desc.imgrid[1];
+
+        int global_rank = get_local_comm_rank();
+        int x           = global_rank % Px;
+        int y           = (global_rank / Px) % Py;
+        int z           = global_rank / (Px * Py);
+
+        int group = y; // group by fixed Y for X->Y transpose
+        int key   = x; // preserve X-order
+
+        desc.use_subcomm = true;
+        desc.subcomm.split(desc.mpi_comm, group, key);
+
+        const auto elem_size = element_size(precision, desc.inArrayType);
+
+        std::vector<BufferPtr> inputBufs
+            = GatherUserBuffers(BufferPtr::user_input, desc.inFields.front().bricks);
+        std::vector<BufferPtr> outputBufs
+            = GatherUserBuffers(BufferPtr::user_output, desc.outFields.front().bricks);
+
+        std::vector<size_t> inputItems;
+        std::vector<size_t> midItems1;
+        std::vector<size_t> midItems2;
+        std::vector<size_t> outputItems;
+
+        auto MakeTempBufferCtor = [](const std::vector<rocfft_brick_t>& bricks) {
+            return [](size_t userIdx, int comm_rank) {
+                return BufferPtr::temp(std::make_shared<InternalTempBuffer>(comm_rank));
+            };
+        };
+
+        // first set of local FFTs along X
+        C2CField(desc.inFields.front(), {0}, inputBufs, inputBufs, {}, inputItems);
+
+        // transpose X -> Y
+        rocfft_field_t         tmpYField = create_intermediate_field(desc, 1); // align along Y
+        std::vector<BufferPtr> tmpYBufs
+            = GatherUserBuffers(MakeTempBufferCtor(tmpYField.bricks), tmpYField.bricks);
+
+        GlobalTransposeA2A(elem_size,
+                           desc.inFields.front(),
+                           tmpYField,
+                           inputBufs,
+                           tmpYBufs,
+                           inputItems,
+                           midItems1,
+                           "transpose_" + std::to_string(transposeNumber++));
+
+        // second set of local FFTs along Y
+        C2CField(tmpYField, {1}, tmpYBufs, tmpYBufs, midItems1, midItems2);
+
+        // transpose Y -> Z
+        rocfft_field_t tmpZField = create_intermediate_field(desc, 2); // align along Z
+        // std::vector<BufferPtr> tmpZBufs  = GatherUserBuffers(BufferPtr::temp, tmpZField.bricks);
+        std::vector<BufferPtr> tmpZBufs
+            = GatherUserBuffers(MakeTempBufferCtor(tmpZField.bricks), tmpZField.bricks);
+
+        desc.subcomm.split(desc.mpi_comm, z, y); // group by Z
+
+        GlobalTransposeA2A(elem_size,
+                           tmpYField,
+                           tmpZField,
+                           tmpYBufs,
+                           tmpZBufs,
+                           midItems2,
+                           midItems1,
+                           "transpose_" + std::to_string(transposeNumber++));
+
+        // third set of local FFTs along Y
+        C2CField(tmpZField, {2}, tmpZBufs, outputBufs, midItems1, outputItems);
+
+        return true;
+    }
+
+    // default slab depcomposition logic:
     // transform contiguous input dims
+    const auto elem_size = element_size(precision, desc.inArrayType);
 
     // gather up input pointers and allocate temp storage for
     // FFTed contiguous input dims (since we don't want to

--- a/library/src/tree_node.cpp
+++ b/library/src/tree_node.cpp
@@ -535,6 +535,8 @@ void CommPointToPoint::ExecuteAsync(const rocfft_plan     plan,
                                     rocfft_execution_info info,
                                     size_t                multiPlanIdx)
 {
+    std::cout << "Using CommPointToPoint" << std::endl;
+
     rocfft_scoped_device dev(srcLocation.device);
 
     if(LOG_PLAN_ENABLED())
@@ -650,6 +652,8 @@ void CommScatter::ExecuteAsync(const rocfft_plan     plan,
 {
     rocfft_scoped_device dev(srcLocation.device);
 
+    std::cout << "Using CommScatter" << std::endl;
+
     if(LOG_PLAN_ENABLED())
     {
         log_plan("CommScatter\n");
@@ -667,8 +671,10 @@ void CommScatter::ExecuteAsync(const rocfft_plan     plan,
                                          arrayType);
 
         hipError_t err = hipSuccess;
+
         if(op.destLocation.comm_rank == srcLocation.comm_rank)
         {
+            // intra-process communication
             const auto memSize = op.numElems * element_size(precision, arrayType);
             if(local_comm_rank == op.destLocation.comm_rank)
             {
@@ -776,6 +782,9 @@ void CommGather::ExecuteAsync(const rocfft_plan     plan,
                               rocfft_execution_info info,
                               size_t                multiPlanIdx)
 {
+
+    std::cout << "Using CommGather " << std::endl;
+
     if(LOG_PLAN_ENABLED())
     {
         log_plan("CommGather\n");
@@ -912,6 +921,18 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
 {
     // check that we have as many elems in our count/offset buffers as
     // we have ranks
+    this->comm = plan->desc.use_subcomm ? plan->desc.subcomm : plan->desc.mpi_comm;
+
+    int sub_rank = -1, sub_size = -1;
+    MPI_Comm_rank(this->comm, &sub_rank);
+    MPI_Comm_size(this->comm, &sub_size);
+    std::cerr << "[Rank " << sub_rank << "] Using communicator " << this->comm
+              << " of size " << sub_size << std::endl;
+
+    int rank;
+    MPI_Comm_rank(this->comm, &rank);
+    std::cerr << "[Rank " << rank << "] Using communicator " << this->comm << std::endl;
+
     const size_t num_ranks = plan->get_local_comm_size();
     if(sendOffsets.size() != num_ranks || sendCounts.size() != num_ranks
        || recvOffsets.size() != num_ranks || recvCounts.size() != num_ranks)
@@ -947,7 +968,7 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
                                           recvBuf.get(in_buffer, out_buffer, local_comm_rank),
                                           send_count_bytes,
                                           MPI_CHAR,
-                                          plan->desc.mpi_comm,
+                                          this->comm,
                                           &request);
 
         if(mpiret != MPI_SUCCESS)
@@ -993,7 +1014,7 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
                                            intRecvCounts.data(),
                                            intRecvOffsets.data(),
                                            rocfft_type_to_mpi_type(precision, arrayType),
-                                           plan->desc.mpi_comm,
+                                           this->comm,
                                            &request);
 
         if(mpiret != MPI_SUCCESS)
@@ -1035,8 +1056,8 @@ void CommAllToAll::Print(rocfft_ostream& os, const int indent) const
     while(i--)
         indentStr += "    ";
 
-    auto printVec = [&os](const char* prefix, const std::vector<size_t>& vec) {
-        os << prefix << ": ";
+    auto printVec = [&os, &indentStr](const char* prefix, const std::vector<size_t>& vec) {
+        os << indentStr << prefix << ": ";
         for(auto val : vec)
             os << val << " ";
         os << "\n";
@@ -1050,6 +1071,23 @@ void CommAllToAll::Print(rocfft_ostream& os, const int indent) const
     os << indentStr << "CommAllToAll " << precision_name(precision) << " "
        << PrintArrayType(arrayType) << (uniform_counts ? " (MPI_Ialltoall)" : " (MPI_Ialltoallv)")
        << ":\n";
+
+#ifdef ROCFFT_MPI_ENABLE
+    if(comm != MPI_COMM_NULL)
+    {
+        int this_rank = -1, comm_size = -1;
+        MPI_Comm_rank(comm, &this_rank);
+        MPI_Comm_size(comm, &comm_size);
+
+        os << indentStr << " MPI_Comm: " << comm << ", rank " << this_rank << "/" << comm_size
+           << "\n";
+
+        os << indentStr << " ranks in this communicator: ";
+        for(int i = 0; i < comm_size; ++i)
+            os << i << " ";
+        os << "\n";
+    }
+#endif
 
     if(uniform_counts)
     {


### PR DESCRIPTION
Summary of proposed changes:

- Currently, when all-to-all communication is not possible (limited to slab decomposition), rocFFT relies on P2P communication. The approach is to gather data into a single GPU, perform the computation, and then scatter the results, as shown in the profile:

![image](https://github.com/user-attachments/assets/5745334e-29af-444f-949d-da51233e8f52)
 
-  The objective of this PR is to add support for All-to-All communication with sub-communicators for Pencil decomposition