### PR TITLE
Expand fft_param's set_callbacks function to (possibly) set shared memory size(s) too

### DIFF
--- a/shared/fft_params.h
+++ b/shared/fft_params.h
@@ -2174,10 +2174,12 @@ public:
         }
     }
 
-    virtual fft_status set_callbacks(void* load_cb_host,
-                                     void* load_cb_data,
-                                     void* store_cb_host,
-                                     void* store_cb_data)
+    virtual fft_status set_callbacks(void*  load_cb_host,
+                                     void*  load_cb_data,
+                                     void*  store_cb_host,
+                                     void*  store_cb_data,
+                                     size_t load_cb_shared_mem_bytes,
+                                     size_t store_cb_shared_mem_bytes)
     {
         return fft_status_success;
     }

--- a/shared/rocfft_params.h
+++ b/shared/rocfft_params.h
@@ -443,20 +443,22 @@ public:
         return ret;
     }
 
-    fft_status set_callbacks(void* load_cb_host,
-                             void* load_cb_data,
-                             void* store_cb_host,
-                             void* store_cb_data) override
+    fft_status set_callbacks(void*  load_cb_host,
+                             void*  load_cb_data,
+                             void*  store_cb_host,
+                             void*  store_cb_data,
+                             size_t load_cb_shared_mem_bytes  = 0,
+                             size_t store_cb_shared_mem_bytes = 0) override
     {
         if(run_callbacks)
         {
-            auto roc_status
-                = rocfft.execution_info_set_load_callback(info, &load_cb_host, &load_cb_data, 0);
+            auto roc_status = rocfft.execution_info_set_load_callback(
+                info, &load_cb_host, &load_cb_data, load_cb_shared_mem_bytes);
             if(roc_status != rocfft_status_success)
                 return fft_status_from_rocfftparams(roc_status);
 
-            roc_status
-                = rocfft.execution_info_set_store_callback(info, &store_cb_host, &store_cb_data, 0);
+            roc_status = rocfft.execution_info_set_store_callback(
+                info, &store_cb_host, &store_cb_data, store_cb_shared_mem_bytes);
             if(roc_status != rocfft_status_success)
                 return fft_status_from_rocfftparams(roc_status);
         }


### PR DESCRIPTION
Following up here upon completion of [PR#156](https://github.com/ROCm/hipFFT/pull/156).