### PR TITLE
Some additions to fft_params.h

### DIFF
--- a/shared/fft_params.h
+++ b/shared/fft_params.h
@@ -788,6 +788,17 @@ public:
         }
     }
 
+    bool is_inverse() const
+    {
+        return transform_type == fft_transform_type_complex_inverse
+               || transform_type == fft_transform_type_real_inverse;
+    }
+
+    bool is_forward() const
+    {
+        return !is_inverse();
+    }
+
     // Convert to string for output.
     std::string str(const std::string& separator = ", ") const
     {
@@ -2298,6 +2309,7 @@ public:
         ooffset   = params_forward.ioffset;
 
         run_callbacks = params_forward.run_callbacks;
+        multiGPU      = params_forward.multiGPU;
 
         check_output_strides = params_forward.check_output_strides;
 


### PR DESCRIPTION
Following up here upon completion of https://github.com/ROCm/hipFFT/pull/159.

Note: the contents of `shared/accuracy_test.h` had already significantly diverged w.r.t. to the multi-gpu test cases: aligning both versions would require more than a simple cherry-pick.