### PR TITLE
Cherry-pick to release/rocm-rel-7.0: unset external_project to empty list (#629)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ left_nav_title = f"rocFFT {version_number} Documentation"
 # for PDF output on Read the Docs
 project = "rocFFT Documentation"
 author = "Advanced Micro Devices, Inc."
-copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
+copyright = "Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved."
 version = version_number
 release = version_number
 
@@ -24,7 +24,6 @@ docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/xml")
 docs_core.setup()
 
 external_projects_current_project = "rocfft"
-external_projects = []
 
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)


### PR DESCRIPTION
(cherry picked from commit 3e0a8c1430b1ba9e59f3398db5e5e2848bdd77be)

resolves #___

Summary of proposed changes:
-  Fix conf.py error preventing Intersphinx links from being resolved.
-  
-  
